### PR TITLE
Add ability to update members and number of confirmations

### DIFF
--- a/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
+++ b/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
@@ -8,6 +8,7 @@ const {
   members,
   membersEdit,
   numberConfirmations,
+  editName,
 } = routes;
 
 export const getDataBeforeRenderPage = async ({
@@ -28,6 +29,7 @@ export const getDataBeforeRenderPage = async ({
     members,
     membersEdit,
     numberConfirmations,
+    editName,
   ]);
 
   if (!match) return;
@@ -56,6 +58,10 @@ export const getDataBeforeRenderPage = async ({
   }
 
   if (ifRouteIs(numberConfirmations)) {
+    await onMountMultisafe({ multisafeId });
+  }
+
+  if (ifRouteIs(editName)) {
     await onMountMultisafe({ multisafeId });
   }
   withLoading && disableLoading();

--- a/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
+++ b/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
@@ -7,6 +7,7 @@ const {
   history,
   members,
   membersEdit,
+  numberConfirmations,
 } = routes;
 
 export const getDataBeforeRenderPage = async ({
@@ -26,6 +27,7 @@ export const getDataBeforeRenderPage = async ({
     history,
     members,
     membersEdit,
+    numberConfirmations,
   ]);
 
   if (!match) return;
@@ -53,5 +55,8 @@ export const getDataBeforeRenderPage = async ({
     await onMountMultisafe({ multisafeId });
   }
 
+  if (ifRouteIs(numberConfirmations)) {
+    await onMountMultisafe({ multisafeId });
+  }
   withLoading && disableLoading();
 };

--- a/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
+++ b/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
@@ -9,6 +9,7 @@ const {
   membersEdit,
   numberConfirmations,
   editName,
+  remove,
 } = routes;
 
 export const getDataBeforeRenderPage = async ({
@@ -30,6 +31,7 @@ export const getDataBeforeRenderPage = async ({
     membersEdit,
     numberConfirmations,
     editName,
+    remove,
   ]);
 
   if (!match) return;
@@ -62,6 +64,10 @@ export const getDataBeforeRenderPage = async ({
   }
 
   if (ifRouteIs(editName)) {
+    await onMountMultisafe({ multisafeId });
+  }
+
+  if (ifRouteIs(remove)) {
     await onMountMultisafe({ multisafeId });
   }
   withLoading && disableLoading();

--- a/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
+++ b/src/store/general/thunks/helpers/getDataBeforeRenderPage.js
@@ -10,6 +10,7 @@ const {
   numberConfirmations,
   editName,
   remove,
+  disconnect
 } = routes;
 
 export const getDataBeforeRenderPage = async ({
@@ -32,6 +33,7 @@ export const getDataBeforeRenderPage = async ({
     numberConfirmations,
     editName,
     remove,
+    disconnect
   ]);
 
   if (!match) return;
@@ -70,5 +72,10 @@ export const getDataBeforeRenderPage = async ({
   if (ifRouteIs(remove)) {
     await onMountMultisafe({ multisafeId });
   }
+
+  if (ifRouteIs(disconnect)) {
+    await onMountMultisafe({ multisafeId });
+  }
+
   withLoading && disableLoading();
 };

--- a/src/store/multisafe/actions/mountMultisafe.js
+++ b/src/store/multisafe/actions/mountMultisafe.js
@@ -1,10 +1,11 @@
 import { action } from 'easy-peasy';
 
 export const mountMultisafe = action((state, payload) => {
-  const { localMultisafe, contract, balance, members } = payload;
+  const { localMultisafe, contract, balance, members, numConfirmations } = payload;
   state.general.name = localMultisafe.name;
   state.general.multisafeId = localMultisafe.multisafeId;
   state.general.balance = balance.available;
+  state.general.numConfirmations = numConfirmations;
 
   state.members = members.map(({ account_id }) => ({ accountId: account_id }));
   state.entities.contract = contract;

--- a/src/store/multisafe/thunks/index.js
+++ b/src/store/multisafe/thunks/index.js
@@ -6,6 +6,7 @@ import { onTransferTokens } from './onTransferTokens';
 import { onConfirmRequest } from './onConfirmRequest';
 import { onDeleteRequest } from './onDeleteRequest';
 import { onRemoveLocalMultisafe } from './onRemoveLocalMultisafe';
+import { onEditMultisafe } from './onEditMultisafe';
 
 export const thunks = {
   onMountMultisafe,
@@ -16,4 +17,5 @@ export const thunks = {
   onConfirmRequest,
   onDeleteRequest,
   onRemoveLocalMultisafe,
+  onEditMultisafe
 };

--- a/src/store/multisafe/thunks/onEditMultisafe.js
+++ b/src/store/multisafe/thunks/onEditMultisafe.js
@@ -1,6 +1,8 @@
 import { thunk } from 'easy-peasy';
-import { signTransactionByLedger } from '../../multisafe/helpers/signTransactionByLedger';
+import { signTransactionByLedger } from '../helpers/signTransactionByLedger';
 import { getRoute } from '../../../ui/config/routes';
+
+// TEN PLIK PRZENIESC do multisafe/thunks
 
 const serializeData = ({ name, members, num_confirmations }) => ({
   name,
@@ -76,6 +78,9 @@ const signTxByLedger = async (contract, contractActions, actions, multisafeId, s
 };
 
 export const onEditMultisafe = thunk(async (_, payload, { getStoreState, getStoreActions }) => {
+
+  // TESTOWAC DLA KILKU MULTISAFOW NA RAZ, jak jest kilka dodanych czy to dalej dziala poprawnie
+
   const { data, history } = payload;
 
   const state = getStoreState();

--- a/src/store/multisafe/thunks/onEditMultisafe.js
+++ b/src/store/multisafe/thunks/onEditMultisafe.js
@@ -78,9 +78,6 @@ const signTxByLedger = async (contract, contractActions, actions, multisafeId, s
 };
 
 export const onEditMultisafe = thunk(async (_, payload, { getStoreState, getStoreActions }) => {
-
-  // TESTOWAC DLA KILKU MULTISAFOW NA RAZ, jak jest kilka dodanych czy to dalej dziala poprawnie
-
   const { data, history } = payload;
 
   const state = getStoreState();

--- a/src/store/multisafe/thunks/onEditMultisafe.js
+++ b/src/store/multisafe/thunks/onEditMultisafe.js
@@ -97,7 +97,7 @@ export const onEditMultisafe = thunk(async (_, payload, { getStoreState, getStor
     return;
   }
 
-  if (!values.numConfirmations && values.members && !membersActions.length) {
+  if (!values.numConfirmations && !membersActions.length) {
     return;
   }
 

--- a/src/store/multisafe/thunks/onMountMultisafe.js
+++ b/src/store/multisafe/thunks/onMountMultisafe.js
@@ -16,9 +16,10 @@ export const onMountMultisafe = thunk(async (_, payload, { getStoreState, getSto
   const localMultisafe = multisafes.find((multisafe) => multisafe.multisafeId === multisafeId);
 
   try {
-    const [balance, members] = await Promise.all([
+    const [balance, members, numConfirmations] = await Promise.all([
       new Account(near.connection, multisafeId).getAccountBalance(),
       contract.get_members(),
+      contract.get_num_confirmations(),
     ]);
 
     mountMultisafe({
@@ -26,6 +27,7 @@ export const onMountMultisafe = thunk(async (_, payload, { getStoreState, getSto
       contract,
       balance,
       members,
+      numConfirmations
     });
   } catch (e) {
     actions.general.setError({ isError: true, description: e.message });

--- a/src/store/startWork/thunks/index.js
+++ b/src/store/startWork/thunks/index.js
@@ -1,9 +1,7 @@
 import { onCreateMultisafe } from './onCreateMultisafe';
-import { onEditMultisafe } from './onEditMultisafe';
 import { onLoadMultisafe } from './onLoadMultisafe';
 
 export const thunks = {
   onCreateMultisafe,
-  onEditMultisafe,
   onLoadMultisafe,
 };

--- a/src/store/startWork/thunks/index.js
+++ b/src/store/startWork/thunks/index.js
@@ -1,7 +1,9 @@
 import { onCreateMultisafe } from './onCreateMultisafe';
+import { onEditMultisafe } from './onEditMultisafe';
 import { onLoadMultisafe } from './onLoadMultisafe';
 
 export const thunks = {
   onCreateMultisafe,
+  onEditMultisafe,
   onLoadMultisafe,
 };

--- a/src/store/startWork/thunks/onEditMultisafe.js
+++ b/src/store/startWork/thunks/onEditMultisafe.js
@@ -1,10 +1,5 @@
 import { thunk } from 'easy-peasy';
-import { utils } from 'near-api-js';
-import { spaceToSnake } from '../../../utils/format';
 import { signTransactionByLedger } from '../../multisafe/helpers/signTransactionByLedger';
-import { getMultisafeFactoryContract } from '../helpers/getMultisafeFactoryContract';
-import { config } from '../../../near/config';
-import { redirectActions } from '../../../config/redirectActions';
 import { getRoute } from '../../../ui/config/routes';
 
 const serializeData = ({ name, members, num_confirmations }) => ({

--- a/src/store/startWork/thunks/onEditMultisafe.js
+++ b/src/store/startWork/thunks/onEditMultisafe.js
@@ -100,6 +100,10 @@ export const onEditMultisafe = thunk(async (_, payload, { getStoreState, getStor
     ...membersActions
   ]
 
+  if (values.members && !contractActions.length) {
+    return;
+  }
+
   isNearWallet
     ? addEditRequest(contract, contractActions)
     : await signTxByLedger(contract, contractActions, actions, multisafeId, state, history);

--- a/src/store/startWork/thunks/onEditMultisafe.js
+++ b/src/store/startWork/thunks/onEditMultisafe.js
@@ -95,14 +95,19 @@ export const onEditMultisafe = thunk(async (_, payload, { getStoreState, getStor
 
   const membersActions = generateMembersActions(values, members)
   const confirmationsActions = generateConfirmationsActions(values)
+
+  if (values.numConfirmations === numConfirmations) {
+    return;
+  }
+
+  if (!values.numConfirmations && values.members && !membersActions.length) {
+    return;
+  }
+
   const contractActions = [
     ...confirmationsActions,
     ...membersActions
   ]
-
-  if (values.members && !contractActions.length) {
-    return;
-  }
 
   isNearWallet
     ? addEditRequest(contract, contractActions)

--- a/src/store/startWork/thunks/onEditMultisafe.js
+++ b/src/store/startWork/thunks/onEditMultisafe.js
@@ -1,0 +1,122 @@
+import { thunk } from 'easy-peasy';
+import { utils } from 'near-api-js';
+import { spaceToSnake } from '../../../utils/format';
+import { signTransactionByLedger } from '../../multisafe/helpers/signTransactionByLedger';
+import { getMultisafeFactoryContract } from '../helpers/getMultisafeFactoryContract';
+import { config } from '../../../near/config';
+import { redirectActions } from '../../../config/redirectActions';
+import { getRoute } from '../../../ui/config/routes';
+
+// TEN PLIK PRZENIESC do multisafe/thunks
+
+const serializeData = ({ name, multisafeId, members, num_confirmations, amount }) => ({
+  numConfirmations: Number(num_confirmations),
+});
+
+const createMultisafe = (contract, values) => {
+  const { multisafeId, members, numConfirmations, amount } = values;
+
+  return contract.create({
+    args: {
+      name: multisafeId,
+      members,
+      num_confirmations: numConfirmations,
+    },
+    gas: config.maxGas,
+    amount,
+    callbackUrl: getRoute.callbackUrl({ redirectAction: redirectActions.createMultisafe }),
+  });
+};
+
+const signByNearWallet = (contract, values, actions, currentMembers, numConfirmations) => {
+//   actions.general.setTemporaryData({
+//     redirectAction: redirectActions.createMultisafe,
+//     name: values.name,
+//     multisafeId: values.multisafeAccountId,
+//   });
+
+//   createMultisafe(contract, values);
+
+  const currentMembersIds = currentMembers.map(({ accountId }) => accountId)
+  const membersIds = values.members?.map(({ account_id }) => account_id) || []
+  const method = 'add_request_and_confirm';
+
+  const addMembersActions = membersIds.length
+    ? values.members.reduce((x, member) => [
+      ...x,
+      ...(!currentMembersIds.includes(member.account_id) ? [{
+          type: 'AddMember',
+          member: {
+              account_id: member.account_id
+          }
+      }] : [])
+    ], [])
+    : []
+
+
+  const deleteMembersActions = membersIds.length
+    ? currentMembers.reduce((x, currentMember) => [
+      ...x,
+      ...(!membersIds.includes(currentMember.accountId) ? [{
+          type: 'DeleteMember',
+          member: {
+              account_id: currentMember.accountId
+          }
+      }] : [])
+    ], [])
+    : []
+
+  const changeConfirmations = values.numConfirmations
+    ? [{ type: 'SetNumConfirmations', num_confirmations: values.numConfirmations }]
+    : []
+
+  const args = {
+    args: {
+      request: {
+        receiver_id: contract.contractId,
+        actions: [
+            ...changeConfirmations,
+            ...addMembersActions,
+            ...deleteMembersActions
+        ],
+      },
+    },
+  }
+
+  return contract[method](args);
+};
+
+const signTxByLedger = async (contract, values, state, actions, history) => {
+  await signTransactionByLedger({
+    actionName: 'Create Multi Safe',
+    state,
+    actions,
+    contractMethod: () => createMultisafe(contract, values),
+    callback: () => {
+      actions.multisafe.addMultisafe({
+        name: values.name,
+        multisafeId: values.multisafeAccountId,
+      });
+      history.push(getRoute.dashboard(values.multisafeAccountId));
+    },
+  });
+};
+
+export const onEditMultisafe = thunk(async (_, payload, { getStoreState, getStoreActions }) => {
+  // TESTOWAC DLA KILKU MULTISAFOW NA RAZ, jak jest kilka dodanych czy to dalej dziala poprawnie
+  const { data, history } = payload;
+  const state = getStoreState();
+  const isNearWallet = state.general.selectors.isNearWallet;
+
+  const actions = getStoreActions();
+  const factoryContract = getMultisafeFactoryContract(state);
+  const values = serializeData(data);
+
+  const contract = state.multisafe.entities.contract;
+  const members = state.multisafe.members;
+  const numConfirmations = state.multisafe.general.numConfirmations;
+
+  isNearWallet
+    ? signByNearWallet(contract, values, actions, members, numConfirmations)
+    : await signTxByLedger(factoryContract, values, state, actions, history);
+});

--- a/src/ui/components/App.jsx
+++ b/src/ui/components/App.jsx
@@ -24,6 +24,7 @@ export const App = () => (
           routes.numberConfirmations,
           routes.editName,
           routes.remove,
+          routes.disconnect,
         ]}
         component={Main}
       />

--- a/src/ui/components/App.jsx
+++ b/src/ui/components/App.jsx
@@ -21,6 +21,7 @@ export const App = () => (
           routes.history,
           routes.members,
           routes.membersEdit,
+          routes.numberConfirmations,
         ]}
         component={Main}
       />

--- a/src/ui/components/App.jsx
+++ b/src/ui/components/App.jsx
@@ -23,6 +23,7 @@ export const App = () => (
           routes.membersEdit,
           routes.numberConfirmations,
           routes.editName,
+          routes.remove,
         ]}
         component={Main}
       />

--- a/src/ui/components/App.jsx
+++ b/src/ui/components/App.jsx
@@ -22,6 +22,7 @@ export const App = () => (
           routes.members,
           routes.membersEdit,
           routes.numberConfirmations,
+          routes.editName,
         ]}
         component={Main}
       />

--- a/src/ui/components/Main/FormElements/AccountId/AccountId.jsx
+++ b/src/ui/components/Main/FormElements/AccountId/AccountId.jsx
@@ -1,0 +1,32 @@
+import { Typography } from '@material-ui/core';
+import { TextField } from '../../../../general/TextField/TextField';
+import { BulletHeading } from '../../../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../../../general/ContentSeparator/ContentSeparator';
+
+export const AccountId = ({ control, classNames, hasError, errorMessage }) => (
+  <>
+    <BulletHeading>Multi Safe ID</BulletHeading>
+    <Typography className={classNames?.description}>
+      Second, choose Multi Safe ID. It is public and should be unique in the blockchain.
+    </Typography>
+    <section className={classNames?.createMultisafeBlock}>
+      <TextField
+        control={control}
+        name="multisafeId"
+        variant="outlined"
+        placeholder="Multi Safe ID*"
+        fullWidth
+        className={classNames?.textField}
+        error={hasError}
+        helperText={errorMessage}
+        InputProps={{
+          classes: {
+            root: classNames.textFieldInputRoot,
+            notchedOutline: classNames.textFieldInputNotchedOutline,
+          },
+        }}
+      />
+    </section>
+    <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
+  </>
+);

--- a/src/ui/components/Main/FormElements/AccountId/AccountId.jsx
+++ b/src/ui/components/Main/FormElements/AccountId/AccountId.jsx
@@ -1,14 +1,16 @@
 import { Typography } from '@material-ui/core';
-import { TextField } from '../../../../general/TextField/TextField';
-import { BulletHeading } from '../../../../general/BulletHeading/BulletHeading';
-import { ContentSeparator } from '../../../../../general/ContentSeparator/ContentSeparator';
+import { TextField } from '../../general/TextField/TextField';
+import { BulletHeading } from '../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../general/ContentSeparator/ContentSeparator';
 
-export const AccountId = ({ control, classNames, hasError, errorMessage }) => (
+export const AccountId = ({ control, classNames, hasError, errorMessage, editVersion = false }) => (
   <>
     <BulletHeading>Multi Safe ID</BulletHeading>
-    <Typography className={classNames?.description}>
-      Second, choose Multi Safe ID. It is public and should be unique in the blockchain.
-    </Typography>
+    {!editVersion && 
+      <Typography className={classNames?.description}>
+        Second, choose Multi Safe ID. It is public and should be unique in the blockchain.
+      </Typography>
+    }
     <section className={classNames?.createMultisafeBlock}>
       <TextField
         control={control}

--- a/src/ui/components/Main/FormElements/Amount/Amount.jsx
+++ b/src/ui/components/Main/FormElements/Amount/Amount.jsx
@@ -1,0 +1,40 @@
+import { InputAdornment, Typography } from '@material-ui/core';
+import { BulletHeading } from '../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../general/ContentSeparator/ContentSeparator';
+import { Near } from '../../../general/icons/Near';
+import { TextField } from '../../general/TextField/TextField';
+
+export const Amount = ({ control, classNames, hasError, errorMessage }) => (
+  <>
+    <BulletHeading>Deposit funds</BulletHeading>
+    <Typography className={classNames?.description}>
+      To start work with your Multi Safe please deposit funds. To create Multi Safe you need
+      to have at least 5 NEAR
+    </Typography>
+    <section className={classNames?.createMultisafeBlock}>
+      <TextField
+        control={control}
+        name="amount"
+        variant="filled"
+        label="Amount*"
+        fullWidth
+        defaultValue="0"
+        className={classNames?.amountField}
+        error={hasError}
+        helperText={errorMessage}
+        InputProps={{
+          classes: {
+            root: classNames.amountInputRoot,
+          },
+          endAdornment: (
+            <InputAdornment position="end">
+              <Near className={classNames?.icon} />
+              <span className={classNames?.adornmentText}>NEAR</span>
+            </InputAdornment>
+          ),
+        }}
+      />
+    </section>
+    <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
+  </>
+);

--- a/src/ui/components/Main/FormElements/Confirmations/Confirmations.jsx
+++ b/src/ui/components/Main/FormElements/Confirmations/Confirmations.jsx
@@ -1,0 +1,59 @@
+import { FormHelperText, MenuItem, TextField, Typography } from '@material-ui/core';
+import * as R from 'ramda';
+import { useController, useWatch } from 'react-hook-form';
+import { BulletHeading } from '../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../general/ContentSeparator/ContentSeparator';
+
+export const Confirmations = ({ control, classNames, hasError, errorMessage }) => {
+  const watchedMembers =
+    useWatch({
+      control,
+      name: 'members',
+    }) || [];
+
+  const {
+    field: { ref, ...inputProps },
+  } = useController({
+    name: 'num_confirmations',
+    control,
+    rules: { required: true },
+    defaultValue: '',
+  });
+
+  const membersCountList = R.addIndex(R.map)((_, idx) => idx + 1, watchedMembers);
+
+  return (
+    <>
+      <BulletHeading>Confirmations</BulletHeading>
+      <Typography className={classNames?.description}>
+        Specify how many of them have to confirm a transaction before it gets executed. In general,
+        the more confirmations required, the more secure is your Safe.
+      </Typography>
+      <section className={classNames?.createMultisafeBlock}>
+        <TextField
+          id="select"
+          inputRef={ref}
+          variant="filled"
+          label="Confirmations*"
+          disabled={R.isEmpty(membersCountList)}
+          className={classNames?.confirmationsField}
+          select
+          error={hasError}
+          helperText={errorMessage}
+          {...inputProps}
+        >
+          {membersCountList.map((idx) => (
+            <MenuItem
+              value={idx}
+              key={`confirmation-member-${idx}`}
+              className={classNames?.confirmationInput}>
+              {idx}
+            </MenuItem>
+          ))}
+        </TextField>
+        {!errorMessage && <FormHelperText id="filled-confirmation-helper-text">of 1 owner(s)</FormHelperText>}
+      </section>
+      <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
+    </>
+  );
+};

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -78,7 +78,8 @@ export const MembersField = ({
             variant="outlined"
             color="primary"
             className={classes.addButton}
-            onClick={appendMember}>
+            onClick={appendMember}
+          >
             Add Member
           </Button>
           <FormHelperText id="members-validation-field" error={watchedMembers < 1}>

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -1,0 +1,82 @@
+import { useFieldArray, useWatch } from 'react-hook-form'
+import { List, ListItem, Button, IconButton, Typography, FormHelperText } from '@material-ui/core';
+import { Delete as DeleteIcon, Add as AddIcon } from '@material-ui/icons';
+import { useStyles } from './MembersField.styles';
+import { BulletHeading } from '../../../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../../../general/ContentSeparator/ContentSeparator';
+import { TextField } from '../../../../general/TextField/TextField';
+
+export const MembersField = ({
+  control,
+  getValues,
+  name,
+  classNames,
+  errors,
+}) => {
+  const classes = useStyles();
+  const { fields, append, remove } = useFieldArray({ control, name });
+  const watchedMembers =
+    useWatch({
+      control,
+      name: 'members',
+    }) || [];
+
+  const appendMember = () => append([{ account_id: getValues('account_id') }]);
+
+  const removeMember = (idx) => remove(idx);
+
+  return (
+    <>
+      <BulletHeading>Members</BulletHeading>
+      <Typography className={classNames?.description}>
+        Your Safe will have one or more Members. We have prefilled the first Member with your
+        connected wallet details, but you are free to change this to a different Member.
+      </Typography>
+      <Typography className={classNames?.description}>
+        Add additional Members (e.g. wallets of your teammates). In general, the more confirmations
+        required, the more secure is your Safe.
+      </Typography>
+      <section className={classNames?.createMultisafeBlock}>
+        <List>
+          {fields.map((item, idx) => (
+            <ListItem key={item.id} disableGutters>
+              <TextField
+                control={control}
+                name={`members[${idx}].account_id`}
+                variant="filled"
+                label="Member Account ID*"
+                className={classes.memberAddress}
+                fullWidth
+                error={!!errors?.members?.[idx]?.account_id}
+                helperText={!!errors?.members && errors?.members?.[idx]?.account_id.message}
+                InputProps={{
+                  classes: {
+                    root: classes.memberAddressInput,
+                  },
+                }}
+              />
+              <IconButton className={classes.iconButton} onClick={removeMember}>
+                <DeleteIcon className={classes.icon} />
+              </IconButton>
+            </ListItem>
+          ))}
+        </List>
+        <section>
+          <Button
+            startIcon={<AddIcon />}
+            type="button"
+            variant="outlined"
+            color="primary"
+            className={classes.addButton}
+            onClick={appendMember}>
+            Add Member
+          </Button>
+          <FormHelperText id="members-validation-field" error={watchedMembers < 1}>
+            {watchedMembers < 1 && errors?.members?.message}
+          </FormHelperText>
+        </section>
+      </section>
+      <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
+    </>
+  );
+};

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -30,14 +30,22 @@ export const MembersField = ({
   return (
     <>
       <BulletHeading>Members</BulletHeading>
-      {!editVersion &&
-        <Typography className={classNames?.description}>
-          Your Safe will have one or more Members. We have prefilled the first Member with your connected wallet details, but you are free to change this to a different Member.
-        </Typography>
+      {editVersion 
+        ? (
+          <Typography className={classNames?.description}>
+            Add or remove Members. In general, the more confirmations required, the more secure is your Safe.
+          </Typography>
+        ) : (
+          <>
+            <Typography className={classNames?.description}>
+              Your Safe will have one or more Members. We have prefilled the first Member with your connected wallet details, but you are free to change this to a different Member.
+            </Typography>
+            <Typography className={classNames?.description}>
+              Add additional Members (e.g. wallets of your teammates). In general, the more confirmations required, the more secure is your Safe.
+            </Typography>
+          </>
+        )
       }
-      <Typography className={classNames?.description}>
-        Add additional Members (e.g. wallets of your teammates). In general, the more confirmations required, the more secure is your Safe.
-      </Typography>
       <section className={classNames?.createMultisafeBlock}>
         <List>
           {fields.map((item, idx) => (

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -2,9 +2,9 @@ import { useFieldArray, useWatch } from 'react-hook-form'
 import { List, ListItem, Button, IconButton, Typography, FormHelperText } from '@material-ui/core';
 import { Delete as DeleteIcon, Add as AddIcon } from '@material-ui/icons';
 import { useStyles } from './MembersField.styles';
-import { BulletHeading } from '../../../../general/BulletHeading/BulletHeading';
-import { ContentSeparator } from '../../../../../general/ContentSeparator/ContentSeparator';
-import { TextField } from '../../../../general/TextField/TextField';
+import { BulletHeading } from '../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../general/ContentSeparator/ContentSeparator';
+import { TextField } from '../../general/TextField/TextField';
 
 export const MembersField = ({
   control,
@@ -12,8 +12,10 @@ export const MembersField = ({
   name,
   classNames,
   errors,
+  editVersion = false
 }) => {
   const classes = useStyles();
+
   const { fields, append, remove } = useFieldArray({ control, name });
   const watchedMembers =
     useWatch({
@@ -28,13 +30,13 @@ export const MembersField = ({
   return (
     <>
       <BulletHeading>Members</BulletHeading>
+      {!editVersion &&
+        <Typography className={classNames?.description}>
+          Your Safe will have one or more Members. We have prefilled the first Member with your connected wallet details, but you are free to change this to a different Member.
+        </Typography>
+      }
       <Typography className={classNames?.description}>
-        Your Safe will have one or more Members. We have prefilled the first Member with your
-        connected wallet details, but you are free to change this to a different Member.
-      </Typography>
-      <Typography className={classNames?.description}>
-        Add additional Members (e.g. wallets of your teammates). In general, the more confirmations
-        required, the more secure is your Safe.
+        Add additional Members (e.g. wallets of your teammates). In general, the more confirmations required, the more secure is your Safe.
       </Typography>
       <section className={classNames?.createMultisafeBlock}>
         <List>

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.styles.js
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.styles.js
@@ -4,7 +4,6 @@ const styles = {
   container: {
     width: 620,
   },
-  addMemberInput: {},
   memberAddress: {
     width: '100%',
   },

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.styles.js
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.styles.js
@@ -1,0 +1,34 @@
+import { makeStyles } from '@material-ui/core';
+
+const styles = {
+  container: {
+    width: 620,
+  },
+  addMemberInput: {},
+  memberAddress: {
+    width: '100%',
+  },
+  memberAddressInput: {
+    fontSize: 16,
+    fontWeight: 900,
+  },
+  addButton: {
+    borderColor: 'rgba(0, 0, 0, 0.12)',
+    borderRadius: 8,
+  },
+  iconButton: {
+    padding: '8px',
+    margin: '0 16px',
+  },
+  icon: {
+    color: '#989898',
+    '&:hover': {
+      color: '#e40029',
+    },
+  },
+  addIcon: {
+    color: '#00c08b',
+  },
+};
+
+export const useStyles = makeStyles(styles, { name: 'MembersField' });

--- a/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
+++ b/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
@@ -1,0 +1,36 @@
+import { Typography } from '@material-ui/core';
+import { TextField } from '../../../../general/TextField/TextField';
+import { BulletHeading } from '../../../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../../../general/ContentSeparator/ContentSeparator';
+
+export const MultisafeName = ({ control, classNames, hasError, errorMessage }) => (
+  <>
+    <BulletHeading>Multi Safe Name</BulletHeading>
+    <Typography className={classNames?.description}>
+      First, let&apos;s give your new Safe a name. This name is only stored locally and will never
+      be shared.
+    </Typography>
+    <section className={classNames?.createMultisafeBlock}>
+      <TextField
+        control={control}
+        name="name"
+        variant="outlined"
+        placeholder="Multi Safe Name*"
+        fullWidth
+        className={classNames?.textField}
+        error={hasError}
+        helperText={errorMessage}
+        InputProps={{
+          classes: {
+            root: classNames.textFieldInputRoot,
+            notchedOutline: classNames.textFieldInputNotchedOutline,
+          },
+        }}
+      />
+    </section>
+    <Typography className={classNames?.description}>
+      By continuing you consent to the terms of use and privacy policy.
+    </Typography>
+    <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
+  </>
+);

--- a/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
+++ b/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
@@ -1,15 +1,16 @@
 import { Typography } from '@material-ui/core';
-import { TextField } from '../../../../general/TextField/TextField';
-import { BulletHeading } from '../../../../general/BulletHeading/BulletHeading';
-import { ContentSeparator } from '../../../../../general/ContentSeparator/ContentSeparator';
+import { TextField } from '../../general/TextField/TextField';
+import { BulletHeading } from '../../general/BulletHeading/BulletHeading';
+import { ContentSeparator } from '../../../general/ContentSeparator/ContentSeparator';
 
-export const MultisafeName = ({ control, classNames, hasError, errorMessage }) => (
+export const MultisafeName = ({ control, classNames, hasError, errorMessage, editVersion = false }) => (
   <>
     <BulletHeading>Multi Safe Name</BulletHeading>
-    <Typography className={classNames?.description}>
-      First, let&apos;s give your new Safe a name. This name is only stored locally and will never
-      be shared.
-    </Typography>
+    {!editVersion && 
+      <Typography className={classNames?.description}>
+        First, let&apos;s give your new Safe a name. This name is only stored locally and will never be shared.
+      </Typography>
+    }
     <section className={classNames?.createMultisafeBlock}>
       <TextField
         control={control}
@@ -28,9 +29,11 @@ export const MultisafeName = ({ control, classNames, hasError, errorMessage }) =
         }}
       />
     </section>
-    <Typography className={classNames?.description}>
-      By continuing you consent to the terms of use and privacy policy.
-    </Typography>
+    {!editVersion && 
+      <Typography className={classNames?.description}>
+        By continuing you consent to the terms of use and privacy policy.
+      </Typography>
+    }
     <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
   </>
 );

--- a/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
+++ b/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
@@ -6,11 +6,15 @@ import { ContentSeparator } from '../../../general/ContentSeparator/ContentSepar
 export const MultisafeName = ({ control, classNames, hasError, errorMessage, editVersion = false }) => (
   <>
     <BulletHeading>Multi Safe Name</BulletHeading>
-    {!editVersion && 
+    {editVersion ? (
+      <Typography className={classNames?.description}>
+        This name is only stored locally and will never be shared.
+      </Typography>
+    ) : (
       <Typography className={classNames?.description}>
         First, let&apos;s give your new Safe a name. This name is only stored locally and will never be shared.
       </Typography>
-    }
+    )}
     <section className={classNames?.createMultisafeBlock}>
       <TextField
         control={control}

--- a/src/ui/components/Main/Main.jsx
+++ b/src/ui/components/Main/Main.jsx
@@ -25,6 +25,7 @@ export const Main = () => (
           routes.members,
           routes.membersEdit,
           routes.numberConfirmations,
+          routes.editName,
         ]}
         component={MultiSafe}
       />

--- a/src/ui/components/Main/Main.jsx
+++ b/src/ui/components/Main/Main.jsx
@@ -26,6 +26,7 @@ export const Main = () => (
           routes.membersEdit,
           routes.numberConfirmations,
           routes.editName,
+          routes.remove,
         ]}
         component={MultiSafe}
       />

--- a/src/ui/components/Main/Main.jsx
+++ b/src/ui/components/Main/Main.jsx
@@ -24,6 +24,7 @@ export const Main = () => (
           routes.history,
           routes.members,
           routes.membersEdit,
+          routes.numberConfirmations,
         ]}
         component={MultiSafe}
       />

--- a/src/ui/components/Main/Main.jsx
+++ b/src/ui/components/Main/Main.jsx
@@ -27,6 +27,7 @@ export const Main = () => (
           routes.numberConfirmations,
           routes.editName,
           routes.remove,
+          routes.disconnect
         ]}
         component={MultiSafe}
       />

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Disconnect.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Disconnect.jsx
@@ -1,5 +1,5 @@
 import { useStyles } from './EditMultisafe.styles';
-import { FormConfirmations } from './Form/FormConfirmations';
+import { FormDisconnect } from './Form/FormDisconnect';
 
 export const Disconnect = () => {
   const classes = useStyles();
@@ -7,9 +7,9 @@ export const Disconnect = () => {
   return (
     <div className={classes.container}>
       <div className={classes.headerWrapper}>
-        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+        <h1 className={classes.title}>Disconnect Account</h1>
       </div>
-      <FormConfirmations />
+      <FormDisconnect />
     </div>
   );
 };

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Disconnect.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Disconnect.jsx
@@ -1,0 +1,15 @@
+import { useStyles } from './EditMultisafe.styles';
+import { FormConfirmations } from './Form/FormConfirmations';
+
+export const Disconnect = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.headerWrapper}>
+        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+      </div>
+      <FormConfirmations />
+    </div>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/EditConfirmations.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/EditConfirmations.jsx
@@ -1,0 +1,15 @@
+import { useStyles } from './EditMultisafe.styles';
+import { FormConfirmations } from './Form/FormConfirmations';
+
+export const EditConfirmations = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.headerWrapper}>
+        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+      </div>
+      <FormConfirmations />
+    </div>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/EditMembers.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/EditMembers.jsx
@@ -1,0 +1,15 @@
+import { useStyles } from './EditMultisafe.styles';
+import { FormMembers } from './Form/FormMembers';
+
+export const EditMembers = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.headerWrapper}>
+        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+      </div>
+      <FormMembers />
+    </div>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/EditMultisafe.styles.js
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/EditMultisafe.styles.js
@@ -1,0 +1,38 @@
+import { makeStyles } from '@material-ui/core';
+
+const styles = {
+  container: {
+    width: '620px',
+  },
+  headerWrapper: {
+    display: 'grid',
+    gridTemplateColumns: '10% 80% 10%',
+    gridTemplateRows: 'auto',
+    gridTemplateAreas: `
+      'a b .'
+    `,
+    alignItems: 'center',
+    marginTop: 36,
+  },
+  goBack: {
+    gridArea: 'a',
+    justifySelf: 'start',
+    padding: 0,
+  },
+  icon: {
+    height: 28,
+    width: 28,
+    padding: 0,
+    color: 'rgba(0, 0, 0, 87)',
+
+  },
+  title: {
+    gridArea: 'b',
+    justifySelf: 'center',
+    fontSize: 34,
+    fontWeight: 900,
+    margin: 0,
+  },
+};
+
+export const useStyles = makeStyles(styles, { name: 'CreateMultisafe' });

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/EditName.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/EditName.jsx
@@ -1,5 +1,5 @@
 import { useStyles } from './EditMultisafe.styles';
-import { FormConfirmations } from './Form/FormConfirmations';
+import { FormName } from './Form/FormName';
 
 export const EditName = () => {
   const classes = useStyles();
@@ -9,7 +9,7 @@ export const EditName = () => {
       <div className={classes.headerWrapper}>
         <h1 className={classes.title}>Edit Existing Multi Safe</h1>
       </div>
-      <FormConfirmations />
+      <FormName />
     </div>
   );
 };

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/EditName.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/EditName.jsx
@@ -1,0 +1,15 @@
+import { useStyles } from './EditMultisafe.styles';
+import { FormConfirmations } from './Form/FormConfirmations';
+
+export const EditName = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.headerWrapper}>
+        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+      </div>
+      <FormConfirmations />
+    </div>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/Form.styles.js
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/Form.styles.js
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 
 const styles = {
-  form: {},
   textField: {
     fontSize: 20,
     fontWeight: 900,

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/Form.styles.js
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/Form.styles.js
@@ -1,0 +1,55 @@
+import { makeStyles } from '@material-ui/core';
+
+const styles = {
+  form: {},
+  textField: {
+    fontSize: 20,
+    fontWeight: 900,
+  },
+  description: {
+    marginTop: 25,
+    fontSize: 14,
+  },
+  textFieldInputRoot: {
+    borderRadius: 8,
+    fontWeight: 900,
+    backgroundColor: '#eaeaea',
+  },
+  textFieldInputNotchedOutline: {
+    border: 'none',
+  },
+  confirmationsField: {
+    width: '50%',
+  },
+  confirmationInput: {
+    fontWeight: 900,
+    fontSize: 16,
+  },
+  amountField: {
+    width: '50%',
+  },
+  amountInputRoot: {
+    fontSize: 16,
+    fontWeight: 900,
+  },
+  adornmentText: {
+    marginLeft: 8,
+    fontWeight: 700,
+    userSelect: 'none',
+  },
+  icon: {
+    height: 20,
+    width: 20,
+  },
+  submitButton: {
+    fontSize: 14,
+    margin: '25px auto 16px',
+    display: 'block',
+  },
+  createMultisafeBlock: {
+    width: '100%',
+    marginTop: 25,
+  },
+};
+
+export const useStyles = makeStyles(styles, { name: 'Form' });

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
@@ -6,7 +6,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useHistory } from 'react-router-dom';
 import { useStyles } from './Form.styles';
 import { Confirmations } from '../../../FormElements/Confirmations/Confirmations';
-import { EditMembersPage } from '../../../../../../utils/validation/EditMembersPage';
+import { EditConfirmationsPage } from '../../../../../../utils/validation/EditMembersPage';
 
 export const FormConfirmations = () => {
   const onEditMultisafe = useStoreActions((actions) => actions.multisafe.onEditMultisafe);
@@ -21,7 +21,7 @@ export const FormConfirmations = () => {
     handleSubmit,
     formState: { errors }
   } = useForm({
-    resolver: yupResolver(EditMembersPage),
+    resolver: yupResolver(EditConfirmationsPage),
     mode: 'all',
     defaultValues: {
       num_confirmations: numConfirmations,

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
@@ -1,3 +1,4 @@
+// import { useEffect } from 'react';
 import { Button } from '@material-ui/core';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
@@ -8,7 +9,7 @@ import { Confirmations } from '../../../FormElements/Confirmations/Confirmations
 import { EditMembersPage } from '../../../../../../utils/validation/EditMembersPage';
 
 export const FormConfirmations = () => {
-  const onEditMultisafe = useStoreActions((actions) => actions.startWork.onEditMultisafe);
+  const onEditMultisafe = useStoreActions((actions) => actions.multisafe.onEditMultisafe);
   const history = useHistory();
   const classes = useStyles();
 
@@ -18,6 +19,7 @@ export const FormConfirmations = () => {
   const {
     control,
     handleSubmit,
+    getValues,
     formState: { errors }
   } = useForm({
     resolver: yupResolver(EditMembersPage),
@@ -41,7 +43,7 @@ export const FormConfirmations = () => {
         errorMessage={!!errors?.num_confirmations && errors?.num_confirmations?.message}
       />
       <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-        Edit Multi Safe
+        Send Request
       </Button>
     </form>
   );

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
@@ -19,7 +19,6 @@ export const FormConfirmations = () => {
   const {
     control,
     handleSubmit,
-    getValues,
     formState: { errors }
   } = useForm({
     resolver: yupResolver(EditMembersPage),

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormConfirmations.jsx
@@ -1,0 +1,48 @@
+import { Button } from '@material-ui/core';
+import { useStoreActions, useStoreState } from 'easy-peasy';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useHistory } from 'react-router-dom';
+import { useStyles } from './Form.styles';
+import { Confirmations } from '../../../FormElements/Confirmations/Confirmations';
+import { EditMembersPage } from '../../../../../../utils/validation/EditMembersPage';
+
+export const FormConfirmations = () => {
+  const onEditMultisafe = useStoreActions((actions) => actions.startWork.onEditMultisafe);
+  const history = useHistory();
+  const classes = useStyles();
+
+  const members = useStoreState((state) => state.multisafe.members || []);
+  const numConfirmations = useStoreState((state) => state.multisafe.general.numConfirmations);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors }
+  } = useForm({
+    resolver: yupResolver(EditMembersPage),
+    mode: 'all',
+    defaultValues: {
+      num_confirmations: numConfirmations,
+      members: members.map((member) => ({
+        account_id: member.accountId
+      })),
+    },
+  });
+
+  const onSubmit = handleSubmit((data) => onEditMultisafe({ data, history }));
+
+  return (
+    <form autoComplete="off" className={classes.form} onSubmit={onSubmit}>
+      <Confirmations
+        control={control}
+        classNames={classes}
+        hasError={!!errors?.num_confirmations}
+        errorMessage={!!errors?.num_confirmations && errors?.num_confirmations?.message}
+      />
+      <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+        Edit Multi Safe
+      </Button>
+    </form>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormDisconnect.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormDisconnect.jsx
@@ -1,0 +1,30 @@
+import { Button, Typography } from '@material-ui/core';
+import { useStoreActions } from 'easy-peasy';
+import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+import { useStyles } from './Form.styles';
+
+export const FormDisconnect = () => {
+  const history = useHistory();
+  const classes = useStyles();
+  const onDisconnect = useStoreActions((actions) => actions.general.onDisconnect);
+
+  const {
+    handleSubmit,
+  } = useForm({
+    mode: 'all',
+  });
+
+  const onSubmit = handleSubmit(() => onDisconnect({ history }));
+
+  return (
+    <form autoComplete="off" className={classes.form} onSubmit={onSubmit}>
+      <Typography className={classes?.description}>
+        Disconnecting the account will not remove the Safe, you will be able to connect your wallet again.
+      </Typography>
+      <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+        Disconnect Account
+      </Button>
+    </form>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormMembers.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormMembers.jsx
@@ -9,7 +9,7 @@ import { MembersField } from '../../../FormElements/MembersField/MembersField';
 
 export const FormMembers = () => {
   const editVersion = true;
-  const onEditMultisafe = useStoreActions((actions) => actions.startWork.onEditMultisafe);
+  const onEditMultisafe = useStoreActions((actions) => actions.multisafe.onEditMultisafe);
   const history = useHistory();
   const classes = useStyles();
   const members = useStoreState((state) => state.multisafe.members || []);

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormMembers.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormMembers.jsx
@@ -42,7 +42,7 @@ export const FormMembers = () => {
         errors={errors}
       />
       <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-        Edit Multi Safe
+        Send Request
       </Button>
     </form>
   );

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormMembers.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormMembers.jsx
@@ -1,0 +1,49 @@
+import { Button } from '@material-ui/core';
+import { useStoreActions, useStoreState } from 'easy-peasy';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useHistory } from 'react-router-dom';
+import { useStyles } from './Form.styles';
+import { EditMembersPage } from '../../../../../../utils/validation/EditMembersPage';
+import { MembersField } from '../../../FormElements/MembersField/MembersField';
+
+export const FormMembers = () => {
+  const editVersion = true;
+  const onEditMultisafe = useStoreActions((actions) => actions.startWork.onEditMultisafe);
+  const history = useHistory();
+  const classes = useStyles();
+  const members = useStoreState((state) => state.multisafe.members || []);
+
+  const {
+    control,
+    handleSubmit,
+    getValues,
+    formState: { errors }
+  } = useForm({
+    resolver: yupResolver(EditMembersPage),
+    mode: 'all',
+    defaultValues: {
+      members: members.map((member) => ({
+        account_id: member.accountId
+      })),
+    },
+  });
+
+  const onSubmit = handleSubmit((data) => onEditMultisafe({ data, history }));
+
+  return (
+    <form autoComplete="off" className={classes.form} onSubmit={onSubmit}>
+      <MembersField
+        editVersion={editVersion}
+        control={control}
+        getValues={getValues}
+        classNames={classes}
+        name="members"
+        errors={errors}
+      />
+      <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+        Edit Multi Safe
+      </Button>
+    </form>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormName.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormName.jsx
@@ -1,0 +1,48 @@
+import { Button } from '@material-ui/core';
+import { useStoreActions, useStoreState } from 'easy-peasy';
+import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+import { useStyles } from './Form.styles';
+import { MultisafeName } from '../../../FormElements/MultisafeName/MultisafeName';
+import { getRoute } from '../../../../../config/routes';
+
+export const FormName = () => {
+  const editVersion = true;
+  const changeMultisafeName = useStoreActions((actions) => actions.multisafe.changeMultisafeName);
+  const history = useHistory();
+  const classes = useStyles();
+  const name = useStoreState((state) => state.multisafe.general.name);
+  const multisafeId = useStoreState((state) => state.multisafe.general.multisafeId);
+
+  const {
+    control,
+    handleSubmit,
+    getValues,
+    formState: { errors }
+  } = useForm({
+    mode: 'all',
+    defaultValues: {
+      name
+    },
+  });
+
+  const onSubmit = handleSubmit((data) => {
+    changeMultisafeName({ multisafeId, data })
+    history.push(getRoute.dashboard(multisafeId));
+  });
+
+  return (
+    <form autoComplete="off" className={classes.form} onSubmit={onSubmit}>
+      <MultisafeName
+        control={control}
+        classNames={classes}
+        hasError={!!errors?.name}
+        errorMessage={!!errors?.name && errors?.name?.message}
+        editVersion={editVersion}
+      />
+      <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+        Save Changes
+      </Button>
+    </form>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormName.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormName.jsx
@@ -17,7 +17,6 @@ export const FormName = () => {
   const {
     control,
     handleSubmit,
-    getValues,
     formState: { errors }
   } = useForm({
     mode: 'all',

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormRemove.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormRemove.jsx
@@ -1,0 +1,34 @@
+import { Button, Typography } from '@material-ui/core';
+import { useStoreActions, useStoreState } from 'easy-peasy';
+import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+import { useStyles } from './Form.styles';
+
+export const FormRemove = () => {
+  const history = useHistory();
+  const classes = useStyles();
+  const onDisconnect = useStoreActions((actions) => actions.general.onDisconnect);
+  const name = useStoreState((state) => state.multisafe.general.name);
+
+  const {
+    handleSubmit,
+  } = useForm({
+    mode: 'all',
+  });
+
+  const onSubmit = handleSubmit(() => onDisconnect({ history }));
+
+  return (
+    <form autoComplete="off" className={classes.form} onSubmit={onSubmit}>
+      <Typography className={classes?.description}>
+        {`Are you sure to remove "${name}" from list?`}
+      </Typography>
+      <Typography className={classes?.description}>
+        Notice that it will be removed only locally from your browser - you won&apos;t delete it from the blockchain.
+      </Typography>
+      <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+        Remove Multi Safe
+      </Button>
+    </form>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Remove.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Remove.jsx
@@ -1,0 +1,15 @@
+import { useStyles } from './EditMultisafe.styles';
+import { FormConfirmations } from './Form/FormConfirmations';
+
+export const Remove = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.headerWrapper}>
+        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+      </div>
+      <FormConfirmations />
+    </div>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Remove.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Remove.jsx
@@ -1,5 +1,5 @@
 import { useStyles } from './EditMultisafe.styles';
-import { FormConfirmations } from './Form/FormConfirmations';
+import { FormRemove } from './Form/FormRemove';
 
 export const Remove = () => {
   const classes = useStyles();
@@ -7,9 +7,9 @@ export const Remove = () => {
   return (
     <div className={classes.container}>
       <div className={classes.headerWrapper}>
-        <h1 className={classes.title}>Edit Existing Multi Safe</h1>
+        <h1 className={classes.title}>Remove Multi Safe</h1>
       </div>
-      <FormConfirmations />
+      <FormRemove />
     </div>
   );
 };

--- a/src/ui/components/Main/MultiSafe/MultiSafe.jsx
+++ b/src/ui/components/Main/MultiSafe/MultiSafe.jsx
@@ -12,6 +12,7 @@ import { useStyles } from './MultiSafe.styles';
 import { EditMembers } from './EditMultisafe/EditMembers';
 import { EditConfirmations } from './EditMultisafe/EditConfirmations';
 import { EditName } from './EditMultisafe/EditName';
+import { Remove } from './EditMultisafe/Remove';
 
 export const MultiSafe = () => {
   const [isListOpen, setListOpen] = useState(false);
@@ -34,6 +35,7 @@ export const MultiSafe = () => {
           <Route exact path={routes.membersEdit} component={EditMembers} />
           <Route exact path={routes.numberConfirmations} component={EditConfirmations} />
           <Route exact path={routes.editName} component={EditName} />
+          <Route exact path={routes.remove} component={Remove} />
         </Switch>
         <Footer />
       </div>

--- a/src/ui/components/Main/MultiSafe/MultiSafe.jsx
+++ b/src/ui/components/Main/MultiSafe/MultiSafe.jsx
@@ -11,6 +11,7 @@ import { routes } from '../../../config/routes';
 import { useStyles } from './MultiSafe.styles';
 import { EditMembers } from './EditMultisafe/EditMembers';
 import { EditConfirmations } from './EditMultisafe/EditConfirmations';
+import { EditName } from './EditMultisafe/EditName';
 
 export const MultiSafe = () => {
   const [isListOpen, setListOpen] = useState(false);
@@ -32,6 +33,7 @@ export const MultiSafe = () => {
           <Route exact path={routes.members} component={Members} />
           <Route exact path={routes.membersEdit} component={EditMembers} />
           <Route exact path={routes.numberConfirmations} component={EditConfirmations} />
+          <Route exact path={routes.editName} component={EditName} />
         </Switch>
         <Footer />
       </div>

--- a/src/ui/components/Main/MultiSafe/MultiSafe.jsx
+++ b/src/ui/components/Main/MultiSafe/MultiSafe.jsx
@@ -13,6 +13,7 @@ import { EditMembers } from './EditMultisafe/EditMembers';
 import { EditConfirmations } from './EditMultisafe/EditConfirmations';
 import { EditName } from './EditMultisafe/EditName';
 import { Remove } from './EditMultisafe/Remove';
+import { Disconnect } from './EditMultisafe/Disconnect';
 
 export const MultiSafe = () => {
   const [isListOpen, setListOpen] = useState(false);
@@ -36,6 +37,7 @@ export const MultiSafe = () => {
           <Route exact path={routes.numberConfirmations} component={EditConfirmations} />
           <Route exact path={routes.editName} component={EditName} />
           <Route exact path={routes.remove} component={Remove} />
+          <Route exact path={routes.disconnect} component={Disconnect} />
         </Switch>
         <Footer />
       </div>

--- a/src/ui/components/Main/MultiSafe/MultiSafe.jsx
+++ b/src/ui/components/Main/MultiSafe/MultiSafe.jsx
@@ -9,6 +9,7 @@ import { History } from './History/History';
 import { Members } from './Members/Members';
 import { routes } from '../../../config/routes';
 import { useStyles } from './MultiSafe.styles';
+import { EditMembers } from './EditMultisafe/EditMembers';
 
 export const MultiSafe = () => {
   const [isListOpen, setListOpen] = useState(false);
@@ -28,6 +29,7 @@ export const MultiSafe = () => {
           <Route exact path={routes.dashboard} component={Dashboard} />
           <Route exact path={routes.history} component={History} />
           <Route exact path={routes.members} component={Members} />
+          <Route exact path={routes.membersEdit} component={EditMembers} />
         </Switch>
         <Footer />
       </div>

--- a/src/ui/components/Main/MultiSafe/MultiSafe.jsx
+++ b/src/ui/components/Main/MultiSafe/MultiSafe.jsx
@@ -10,6 +10,7 @@ import { Members } from './Members/Members';
 import { routes } from '../../../config/routes';
 import { useStyles } from './MultiSafe.styles';
 import { EditMembers } from './EditMultisafe/EditMembers';
+import { EditConfirmations } from './EditMultisafe/EditConfirmations';
 
 export const MultiSafe = () => {
   const [isListOpen, setListOpen] = useState(false);
@@ -30,6 +31,7 @@ export const MultiSafe = () => {
           <Route exact path={routes.history} component={History} />
           <Route exact path={routes.members} component={Members} />
           <Route exact path={routes.membersEdit} component={EditMembers} />
+          <Route exact path={routes.numberConfirmations} component={EditConfirmations} />
         </Switch>
         <Footer />
       </div>

--- a/src/ui/components/Main/MultiSafe/MultisafeList/MultisafeList.styles.js
+++ b/src/ui/components/Main/MultiSafe/MultisafeList/MultisafeList.styles.js
@@ -5,7 +5,7 @@ const styles = (theme) => ({
     gridArea: 'b',
     width: 360,
     backgroundColor: '#fafafa',
-    zIndex: 2,
+    zIndex: 102,
     position: 'relative'
   },
   topbar: {

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Item/Item.styles.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Item/Item.styles.js
@@ -10,6 +10,16 @@ const styles = (theme) => ({
       backgroundColor: theme.colors.dashboardHoverBgGrey,
     },
   },
+  subContainer: {
+    height: 36,
+    display: 'flex',
+    alignItems: 'center',
+    marginLeft: 48,
+    color: ({ isActive }) => (isActive ? theme.palette.primary.main : theme.colors.dashboardGrey),
+    '&:hover': {
+      backgroundColor: theme.colors.dashboardHoverBgGrey,
+    },
+  },
   icon: {
     marginLeft: 24,
   },

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Item/Item.styles.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Item/Item.styles.js
@@ -14,7 +14,7 @@ const styles = (theme) => ({
     height: 36,
     display: 'flex',
     alignItems: 'center',
-    marginLeft: 48,
+    paddingLeft: 48,
     color: ({ isActive }) => (isActive ? theme.palette.primary.main : theme.colors.dashboardGrey),
     '&:hover': {
       backgroundColor: theme.colors.dashboardHoverBgGrey,

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Item/SubItem.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Item/SubItem.jsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom';
+import { useStyles } from './Item.styles';
+
+export const SubItem = ({ item: { name, path, isActive } }) => {
+  const classes = useStyles({ isActive });
+
+  return (
+    <Link to={path}>
+      <div className={classes.subContainer}>
+        <span className={classes.name}>{name}</span>
+      </div>
+    </Link>
+  );
+};

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Navigation.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/Navigation.jsx
@@ -1,17 +1,23 @@
 import { useRouteMatch } from 'react-router';
 import { Item } from './Item/Item';
+import { SubItem } from './Item/SubItem';
 import { getItems } from './getItems';
 import { useStyles } from './Navigation.styles';
 
 export const Navigation = () => {
   const match = useRouteMatch();
   const classes = useStyles();
-
   const items = getItems(match);
+  
   return (
     <div className={classes.container}>
       {items.map((item) => (
-        <Item key={item.path} item={item} />
+        <div key={item.path}>
+          <Item item={item} />
+          {item.subItems?.map((subItem) => (
+            <SubItem key={`sub-${subItem.path}`} item={subItem} />
+          ))}
+        </div>
       ))}
     </div>
   );

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
@@ -1,4 +1,4 @@
-import { Dashboard, People, History, Settings } from '@material-ui/icons';
+import { Dashboard, People, Settings } from '@material-ui/icons';
 import { routes, getRoute } from '../../../../../config/routes';
 
 const items = [

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
@@ -3,16 +3,19 @@ import { routes, getRoute } from '../../../../../config/routes';
 
 const items = [
   {
-    name: 'Dashboard',
+    name: 'Requests',
     route: routes.dashboard,
     getPath: getRoute.dashboard,
     icon: Dashboard,
-  },
-  {
-    name: 'History',
-    route: routes.history,
-    getPath: getRoute.history,
-    icon: History,
+    subItems: [{
+      name: 'Pending',
+      route: routes.dashboard,
+      getPath: getRoute.dashboard,
+    },{
+      name: 'Completed',
+      route: routes.history,
+      getPath: getRoute.history,
+    }]
   },
   {
     name: 'Members',

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
@@ -1,4 +1,4 @@
-import { Dashboard, People, History } from '@material-ui/icons';
+import { Dashboard, People, History, Settings } from '@material-ui/icons';
 import { routes, getRoute } from '../../../../../config/routes';
 
 const items = [
@@ -20,12 +20,46 @@ const items = [
     getPath: getRoute.members,
     icon: People,
   },
+  {
+    name: 'Settings',
+    route: routes.membersEdit,
+    getPath: getRoute.membersEdit,
+    icon: Settings,
+    subItems: [{
+      name: 'Edit Members',
+      route: routes.membersEdit,
+      getPath: getRoute.membersEdit,
+    }, {
+      name: 'Edit Confirmations Num',
+      route: routes.numberConfirmations,
+      getPath: getRoute.numberConfirmations,
+    }, {
+      name: 'Edit Name',
+      route: routes.editName,
+      getPath: getRoute.editName,
+    }, {
+      name: 'Remove Multi Safe',
+      route: routes.remove,
+      getPath: getRoute.remove,
+    }, {
+      name: 'Disconnect',
+      route: routes.disconnect,
+      getPath: getRoute.disconnect,
+    }]
+  },
 ];
 
 export const getItems = (match) =>
-  items.map(({ name, icon, getPath, route }) => ({
+  items.map(({ name, icon, getPath, route, subItems }) => ({
     name,
     icon,
     path: getPath(match.params.multisafeId),
-    isActive: route === match.path,
+    isActive: subItems?.length
+      ? subItems.some((subItem) => match.path === subItem.route)
+      : route === match.path,
+    subItems: subItems?.map((subItem) => ({
+      name: subItem.name,
+      path: subItem.getPath(match.params.multisafeId),
+      isActive: subItem.route === match.path,
+    }))
   }));

--- a/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Navigation/getItems.js
@@ -42,7 +42,7 @@ const items = [
       route: routes.remove,
       getPath: getRoute.remove,
     }, {
-      name: 'Disconnect',
+      name: 'Disconnect Account',
       route: routes.disconnect,
       getPath: getRoute.disconnect,
     }]

--- a/src/ui/components/Main/MultiSafe/Sidebar/Sidebar.styles.js
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Sidebar.styles.js
@@ -15,6 +15,7 @@ const styles = {
         overflow: 'auto',
         width: '350px'
       },
+    zIndex: 100
   },
   active: {
     ['@media (max-width:767px)']: { // eslint-disable-line no-useless-computed-key

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
@@ -4,11 +4,11 @@ import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useHistory } from 'react-router-dom';
 import { useStyles } from './Form.styles';
-import { MembersField } from './MembersField/MembersField';
-import { AccountId } from './AccountId/AccountId';
-import { MultisafeName } from './MultisafeName/MultisafeName';
-import { Confirmations } from './Confirmations/Confirmations';
-import { Amount } from './Amount/Amount';
+import { MembersField } from '../../../FormElements/MembersField/MembersField';
+import { AccountId } from '../../../FormElements/AccountId/AccountId';
+import { MultisafeName } from '../../../FormElements/MultisafeName/MultisafeName';
+import { Confirmations } from '../../../FormElements/Confirmations/Confirmations';
+import { Amount } from '../../../FormElements/Amount/Amount';
 import { createMultisafeSchema } from '../../../../../../utils/validation/CreateMultisafePage';
 
 export const Form = () => {

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.styles.js
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.styles.js
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 
 const styles = {
-  form: {},
   textField: {
     fontSize: 20,
     fontWeight: 900,

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/MembersField/MembersField.styles.js
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/MembersField/MembersField.styles.js
@@ -4,7 +4,6 @@ const styles = {
   container: {
     width: 620,
   },
-  addMemberInput: {},
   memberAddress: {
     width: '100%',
   },

--- a/src/ui/config/routes.js
+++ b/src/ui/config/routes.js
@@ -13,6 +13,7 @@ export const routes = {
   history: '/multisafe/:multisafeId/history',
   members: '/multisafe/:multisafeId/members',
   membersEdit: '/multisafe/:multisafeId/edit-members',
+  numberConfirmations: '/multisafe/:multisafeId/edit-confirmations',
 };
 
 export const getRoute = {
@@ -21,4 +22,5 @@ export const getRoute = {
   members: (multisafeId) => `/multisafe/${multisafeId}/members`,
   callbackUrl: (params) => `${window.location.origin}/redirect-from-wallet?${qs.stringify(params)}`,
   membersEdit: (multisafeId) => `/multisafe/${multisafeId}/edit-members`,
+  numberConfirmations: (multisafeId) => `/multisafe/${multisafeId}/edit-confirmations`,
 };

--- a/src/ui/config/routes.js
+++ b/src/ui/config/routes.js
@@ -29,5 +29,4 @@ export const getRoute = {
   editName: (multisafeId) => `/multisafe/${multisafeId}/edit-name`,
   remove: (multisafeId) => `/multisafe/${multisafeId}/remove`,
   disconnect: (multisafeId) => `/multisafe/${multisafeId}/disconnect`,
-  
 };

--- a/src/ui/config/routes.js
+++ b/src/ui/config/routes.js
@@ -14,6 +14,7 @@ export const routes = {
   members: '/multisafe/:multisafeId/members',
   membersEdit: '/multisafe/:multisafeId/edit-members',
   numberConfirmations: '/multisafe/:multisafeId/edit-confirmations',
+  editName: '/multisafe/:multisafeId/edit-name',
 };
 
 export const getRoute = {
@@ -23,4 +24,5 @@ export const getRoute = {
   callbackUrl: (params) => `${window.location.origin}/redirect-from-wallet?${qs.stringify(params)}`,
   membersEdit: (multisafeId) => `/multisafe/${multisafeId}/edit-members`,
   numberConfirmations: (multisafeId) => `/multisafe/${multisafeId}/edit-confirmations`,
+  editName: (multisafeId) => `/multisafe/${multisafeId}/edit-name`,
 };

--- a/src/ui/config/routes.js
+++ b/src/ui/config/routes.js
@@ -16,6 +16,7 @@ export const routes = {
   numberConfirmations: '/multisafe/:multisafeId/edit-confirmations',
   editName: '/multisafe/:multisafeId/edit-name',
   remove: '/multisafe/:multisafeId/remove',
+  disconnect: '/multisafe/:multisafeId/disconnect',
 };
 
 export const getRoute = {
@@ -27,4 +28,6 @@ export const getRoute = {
   numberConfirmations: (multisafeId) => `/multisafe/${multisafeId}/edit-confirmations`,
   editName: (multisafeId) => `/multisafe/${multisafeId}/edit-name`,
   remove: (multisafeId) => `/multisafe/${multisafeId}/remove`,
+  disconnect: (multisafeId) => `/multisafe/${multisafeId}/disconnect`,
+  
 };

--- a/src/ui/config/routes.js
+++ b/src/ui/config/routes.js
@@ -15,6 +15,7 @@ export const routes = {
   membersEdit: '/multisafe/:multisafeId/edit-members',
   numberConfirmations: '/multisafe/:multisafeId/edit-confirmations',
   editName: '/multisafe/:multisafeId/edit-name',
+  remove: '/multisafe/:multisafeId/remove',
 };
 
 export const getRoute = {
@@ -25,4 +26,5 @@ export const getRoute = {
   membersEdit: (multisafeId) => `/multisafe/${multisafeId}/edit-members`,
   numberConfirmations: (multisafeId) => `/multisafe/${multisafeId}/edit-confirmations`,
   editName: (multisafeId) => `/multisafe/${multisafeId}/edit-name`,
+  remove: (multisafeId) => `/multisafe/${multisafeId}/remove`,
 };

--- a/src/utils/validation/EditMembersPage.js
+++ b/src/utils/validation/EditMembersPage.js
@@ -1,0 +1,65 @@
+import * as R from 'ramda';
+import * as yup from 'yup';
+import { config } from '../../near/config';
+import { debounce } from '../debounce';
+
+const requiredMessageType = {
+  name: 'Please enter multisafe name',
+  multisafeId: 'Please enter multisafe ID',
+  members: 'Members needed',
+  account_id: "Please enter member's address",
+  num_confirmations: 'Please select desired number of confirmations',
+  amount: 'Please enter multisafe budget',
+};
+const validationMessageType = {
+  name: 'Name must be at least 4 characters long',
+  multisafeId: 'Multisafe ID must be at least 1 character long',
+  members: 'At least 1 member must be present',
+  account_id: 'Member Account ID must contain network connection type: e.g. alice.near, alice.testnet',
+  num_confirmations: '',
+  amount: 'Enter a valid amount. Minimum is 5 NEAR',
+};
+
+const patterns = {
+  memberAddress:
+  /^[a-zA-Z0-9][a-zA-Z0-9-_]{1,61}[a-zA-Z0-9]\.?(testnet|betanet|localnet|guildnet|near)?/g,
+  amount: /^([5-9]|0?[1-9][0-9]+)$/g,
+};
+
+const isUserExist = debounce(async (value) => {
+  const response = await fetch(config.nodeUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(config.endpoint.setParams({ account_id: value })),
+  });
+  const result = await response.json();
+  return R.has('result', result);
+}, 500);
+
+export const EditMembersPage = yup.object().shape({
+  // name: yup.string().required(requiredMessageType.name),
+  // multisafeId: yup.string().required(requiredMessageType.multisafeId),
+  members: yup
+    .array()
+    .of(
+      yup.object().shape({
+        account_id: yup
+          .string()
+          .required(requiredMessageType.account_id)
+          .matches(patterns.memberAddress, validationMessageType.account_id)
+          .test({
+            message: 'Oops! The user is not found :(',
+            test: isUserExist,
+          }),
+      }),
+    )
+    .required(requiredMessageType.members)
+    .min(1, validationMessageType.members),
+  // num_confirmations: yup.string().required(requiredMessageType.num_confirmations),
+  // amount: yup
+  //   .string()
+  //   .required(requiredMessageType.amount)
+  //   .matches(patterns.amount, validationMessageType.amount),
+});

--- a/src/utils/validation/EditMembersPage.js
+++ b/src/utils/validation/EditMembersPage.js
@@ -39,8 +39,6 @@ const isUserExist = debounce(async (value) => {
 }, 500);
 
 export const EditMembersPage = yup.object().shape({
-  // name: yup.string().required(requiredMessageType.name),
-  // multisafeId: yup.string().required(requiredMessageType.multisafeId),
   members: yup
     .array()
     .of(
@@ -57,9 +55,5 @@ export const EditMembersPage = yup.object().shape({
     )
     .required(requiredMessageType.members)
     .min(1, validationMessageType.members),
-  // num_confirmations: yup.string().required(requiredMessageType.num_confirmations),
-  // amount: yup
-  //   .string()
-  //   .required(requiredMessageType.amount)
-  //   .matches(patterns.amount, validationMessageType.amount),
+  num_confirmations: yup.string().required(requiredMessageType.num_confirmations),
 });

--- a/src/utils/validation/EditMembersPage.js
+++ b/src/utils/validation/EditMembersPage.js
@@ -55,5 +55,8 @@ export const EditMembersPage = yup.object().shape({
     )
     .required(requiredMessageType.members)
     .min(1, validationMessageType.members),
+});
+
+export const EditConfirmationsPage = yup.object().shape({
   num_confirmations: yup.string().required(requiredMessageType.num_confirmations),
 });


### PR DESCRIPTION
Changes:
**1. Added functionality to change Safe members.**
At first, I was planning to add changing members functionality to the `Members` page:
 - `add members` button
 - and `remove` button next to every member.
But the thing is that every action like that needs confirmation from members, so if the user would like to remove 2 members and add 1 member, he would have to create 3 requests. So it will not be a good UX. 
The more complicated to implement but at the same time better UX solution is to remove and add members on the same page and create one request instead of a few.

**2. Added functionality to change the number of confirmations.**
This is implemented as a separate form because it's not possible to change the members and number of confirmations in one request.

**3. Added `Settings` section to the main menu.**
So far the options were scattered in the UI, so I decided to create 3 new forms:
 - Edit Name
 - Remove Multi Safe
 - Disconnect Account
And add all of them in one place, in the main menu, so it's easy to get to without unnecessary clicks.

**4. Reorganized the main menu.**
`Dashboard` and `History` names didn't say much, so I change them to the `Requests` section and two sub-items: `Pending` and `Completed`.