### PR TITLE
Fix members form section on creating/editing Safe page

### DIFF
--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -65,7 +65,7 @@ export const MembersField = ({
                   },
                 }}
               />
-              <IconButton className={classes.iconButton} onClick={removeMember}>
+              <IconButton className={classes.iconButton} onClick={() => removeMember(idx)}>
                 <DeleteIcon className={classes.icon} />
               </IconButton>
             </ListItem>

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -23,7 +23,7 @@ export const MembersField = ({
       name: 'members',
     }) || [];
 
-  const appendMember = () => append([{ account_id: '' }]);
+  const appendMember = () => append();
 
   const removeMember = (idx) => remove(idx);
 

--- a/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
+++ b/src/ui/components/Main/FormElements/MembersField/MembersField.jsx
@@ -23,7 +23,7 @@ export const MembersField = ({
       name: 'members',
     }) || [];
 
-  const appendMember = () => append([{ account_id: getValues('account_id') }]);
+  const appendMember = () => append([{ account_id: '' }]);
 
   const removeMember = (idx) => remove(idx);
 

--- a/src/utils/validation/EditMembersPage.js
+++ b/src/utils/validation/EditMembersPage.js
@@ -1,7 +1,6 @@
 import * as R from 'ramda';
 import * as yup from 'yup';
 import { config } from '../../near/config';
-import { debounce } from '../debounce';
 
 const requiredMessageType = {
   name: 'Please enter multisafe name',
@@ -26,7 +25,7 @@ const patterns = {
   amount: /^([5-9]|0?[1-9][0-9]+)$/g,
 };
 
-const isUserExist = debounce(async (value) => {
+const isUserExist = async (value) => {
   const response = await fetch(config.nodeUrl, {
     method: 'POST',
     headers: {
@@ -36,7 +35,7 @@ const isUserExist = debounce(async (value) => {
   });
   const result = await response.json();
   return R.has('result', result);
-}, 500);
+};
 
 export const EditMembersPage = yup.object().shape({
   members: yup
@@ -49,7 +48,10 @@ export const EditMembersPage = yup.object().shape({
           .matches(patterns.memberAddress, validationMessageType.account_id)
           .test({
             message: 'Oops! The user is not found :(',
-            test: isUserExist,
+            test: async (e) => {
+              const res = await isUserExist(e)
+              return res;
+            },
           }),
       }),
     )


### PR DESCRIPTION
1. Fixed removing member - it was removing the first field, no matter which icon you clicked. Now it's working properly.

2. Adding member - when you removed one field, and then added one field it was by default filled with the accountId from the last field (last, after removing) so finally there were two fields with the same accountId. Now it's working properly.

3. Checking accountId - it was a total mess, validation was wrong, a function that was checking accountId was also working wrongly - the effect was that it was always checking the value from the last field only, no matter which field you were editing or focusing, so basically the validation was not working at all. Now will be working properly.