### PR TITLE
Shift Privacy statement to bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.3.2"
+    "prettier": "^2.3.2",
+    "react-error-overlay": "6.0.9"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -56,5 +57,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
+++ b/src/ui/components/Main/FormElements/MultisafeName/MultisafeName.jsx
@@ -34,11 +34,6 @@ export const MultisafeName = ({ control, classNames, hasError, errorMessage, edi
                 }}
             />
         </section>
-        {!editVersion && 
-      <Typography className={classNames?.description}>
-        By continuing you consent to the terms of use and privacy policy.
-      </Typography>
-        }
         <ContentSeparator bg="rgba(0, 0, 0, 0.87)" height={1} margin="24px 0" />
     </>
 );

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button } from '@material-ui/core';
+import { Button, Typography } from '@material-ui/core';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
@@ -68,8 +68,11 @@ export const Form = () => {
                 errorMessage={!!errors?.amount && errors?.amount?.message}
             />
             <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-        Create Multi Safe
+                Create Multi Safe
             </Button>
+            <Typography className={classes.policy}>
+                By continuing you consent to the terms of use and privacy policy.
+            </Typography>
         </form>
     );
 };

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
@@ -67,12 +67,12 @@ export const Form = () => {
                 hasError={!!errors?.amount}
                 errorMessage={!!errors?.amount && errors?.amount?.message}
             />
-            <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-                Create Multi Safe
-            </Button>
             <Typography className={classes.policy}>
                 By continuing you consent to the terms of use and privacy policy.
             </Typography>
+            <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+                Create Multi Safe
+            </Button>
         </form>
     );
 };

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.styles.js
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.styles.js
@@ -49,6 +49,11 @@ const styles = {
         width: '100%',
         marginTop: 25,
     },
+    policy: {
+        marginTop: 25,
+        fontSize: 14,
+        textAlign: 'center',
+    },
 };
 
 export const useStyles = makeStyles(styles, { name: 'Form' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9399,10 +9399,10 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-error-overlay@^6.0.9:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
-  integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-hook-form@^7.8.4:
   version "7.24.2"


### PR DESCRIPTION
This PR contains two changes:
1. Shift the privacy statement on create new multisafe account page to buttom:
![image](https://user-images.githubusercontent.com/6027014/175143410-5a236274-0920-4bae-812e-3b95aa7bcb62.png)
![image](https://user-images.githubusercontent.com/6027014/175143457-dddf29f7-034d-4127-8635-f94dd0f68d89.png)

2. Bug fix on broken Hot reloading Module by applying `react-error-overlay`