### PR TITLE
Safely rollback pre wallet-selector state

### DIFF
--- a/src/store/general/thunks/onDisconnect.js
+++ b/src/store/general/thunks/onDisconnect.js
@@ -13,7 +13,7 @@ export const onDisconnect = thunk(async (_, payload, { getStoreState, getStoreAc
     localStorage.clear();
     resetState();
 
-    history.push(routes.welcome);
+    history.replace(routes.welcome);
 
     const nearEntities = await getNearEntities(getStoreState);
 

--- a/src/store/general/thunks/onInitApp/onInitApp.js
+++ b/src/store/general/thunks/onInitApp/onInitApp.js
@@ -12,6 +12,15 @@ export const onInitApp = thunk(async (_, payload, { getStoreState, getStoreActio
     const actions = getStoreActions();
     const initApp = actions.general.initApp;
 
+    // This part of code is to safely rollback wallet-selector
+    // https://github.com/near/ui.multisafe/pull/134
+    const authKey = localStorage.getItem('near_app_wallet_auth_key');
+    if (authKey) {
+        const onDisconnect = actions.general.onDisconnect;
+        localStorage.removeItem('near_app_wallet_auth_key');
+        onDisconnect({ history });
+    }
+
     const nearEntities = await getNearEntities(getStoreState);
 
     initApp({ nearEntities });

--- a/src/store/general/thunks/onInitApp/onInitApp.js
+++ b/src/store/general/thunks/onInitApp/onInitApp.js
@@ -16,16 +16,14 @@ export const onInitApp = thunk(async (_, payload, { getStoreState, getStoreActio
     // This part of code is to safely rollback wallet-selector
     // https://github.com/near/ui.multisafe/pull/134
     const authKey = localStorage.getItem('near_app_wallet_auth_key');
+    const walletType = state.general.user.walletType;
     const onDisconnect = actions.general.onDisconnect;
-    if (authKey) {
+    // if wallet-selector authKey found or unsupported wallet is selected, disconnect
+    if (authKey || !(walletType === 'near-wallet' || walletType === 'ledger')) {
         localStorage.removeItem('near_app_wallet_auth_key');
         onDisconnect({ history });
-    } else {
-        const walletType = state.general.user.walletType;
-        // if selected wallet is not supported, disconnect
-        if (!(walletType === 'near-wallet' || walletType === 'ledger')) {
-            onDisconnect({ history });
-        }
+        await getDataBeforeRenderPage({ actions, history, withLoading: false });
+        return setInit(true);
     }
 
     const nearEntities = await getNearEntities(getStoreState);

--- a/src/store/general/thunks/onInitApp/onInitApp.js
+++ b/src/store/general/thunks/onInitApp/onInitApp.js
@@ -10,22 +10,27 @@ export const onInitApp = thunk(async (_, payload, { getStoreState, getStoreActio
     const { history, setInit } = payload;
 
     const actions = getStoreActions();
+    const state = getStoreState();
     const initApp = actions.general.initApp;
 
     // This part of code is to safely rollback wallet-selector
     // https://github.com/near/ui.multisafe/pull/134
     const authKey = localStorage.getItem('near_app_wallet_auth_key');
+    const onDisconnect = actions.general.onDisconnect;
     if (authKey) {
-        const onDisconnect = actions.general.onDisconnect;
         localStorage.removeItem('near_app_wallet_auth_key');
         onDisconnect({ history });
+    } else {
+        const walletType = state.general.user.walletType;
+        // if selected wallet is not supported, disconnect
+        if (!(walletType === 'near-wallet' || walletType === 'ledger')) {
+            onDisconnect({ history });
+        }
     }
 
     const nearEntities = await getNearEntities(getStoreState);
 
     initApp({ nearEntities });
-
-    const state = getStoreState();
 
     // All redirect from NEAR Wallet leads to /redirect-from-wallet route. If it is the case,
     // handle it and redirect the user to the appropriate page. If not - check if a user has access


### PR DESCRIPTION
This PR contains implementation to safely rollback wallet-selector integration (https://github.com/near/ui.multisafe/pull/134)

This PR also has no effect on existing `near-wallet` and `ledger` login process. 

This PR need to be merged prior to [wallet-selector integration](https://github.com/near/ui.multisafe/pull/134)

