### PR TITLE
fix: show form validation errors in send and function call flows

### DIFF
--- a/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/MakeFunctionCall/MakeFunctionCall.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/MakeFunctionCall/MakeFunctionCall.jsx
@@ -16,7 +16,7 @@ import { TGas } from './TGas/TGas';
 
 export const MakeFunctionCall = forwardRef(({ onClose, tabIndex }, ref) => {
     const onMakeFunctionCall = useStoreActions((actions) => actions.multisafe.onMakeFunctionCall);
-    const { control, handleSubmit, errors } = useForm({
+    const { control, handleSubmit, formState: { errors } } = useForm({
         resolver: yupResolver(makeFunctionCallSchema),
         mode: 'all',
     });
@@ -35,31 +35,31 @@ export const MakeFunctionCall = forwardRef(({ onClose, tabIndex }, ref) => {
                         control={control}
                         classNames={classes}
                         hasError={!!errors?.smartContractAddress}
-                        errorMessage={!!errors?.smartContractAddress && errors?.description?.smartContractAddress}
+                        errorMessage={errors?.smartContractAddress?.message}
                     />
                     <MethodName
                         control={control}
                         classNames={classes}
                         hasError={!!errors?.methodName}
-                        errorMessage={!!errors?.methodName && errors?.description?.methodName}
+                        errorMessage={errors?.methodName?.message}
                     />
                     <Arguments
                         control={control}
                         classNames={classes}
                         hasError={!!errors?.args}
-                        errorMessage={!!errors?.args && errors?.description?.args}
+                        errorMessage={errors?.args?.message}
                     />
                     <Deposit
                         control={control}
                         classNames={classes}
                         hasError={!!errors?.deposit}
-                        errorMessage={!!errors?.deposit && errors?.description?.deposit}
+                        errorMessage={errors?.deposit?.message}
                     />
                     <TGas
                         control={control}
                         classNames={classes}
                         hasError={!!errors?.tGas}
-                        errorMessage={!!errors?.tGas && errors?.description?.tGas}
+                        errorMessage={errors?.tGas?.message}
                     />
                     <Checkbox
                         control={control}

--- a/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendFunds.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendFunds.jsx
@@ -16,7 +16,7 @@ export const SendFunds = forwardRef(({ onClose, tabIndex }, ref) => {
     const onTransferTokens = useStoreActions((actions) => actions.multisafe.onTransferTokens);
     const fungibleTokens = useStoreState((store) => store.multisafe.general.fungibleTokens);
 
-    const { control, handleSubmit, setValue, errors } = useForm({
+    const { control, handleSubmit, setValue, formState: { errors } } = useForm({
         resolver: yupResolver(sendFundsSchema),
         mode: 'all',
     });

--- a/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendNFTs.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendNFTs.jsx
@@ -109,7 +109,7 @@ export const SendNFTs = forwardRef(({ onClose, tabIndex }, ref) => {
     const nonFungibleTokens = useStoreState(({ multisafe }) => multisafe.general.nonFungibleTokens);
     const onTransferNFT = useStoreActions((actions) => actions.multisafe.onTransferNFT);
 
-    const { control, handleSubmit, errors } = useForm({
+    const { control, handleSubmit, formState: { errors } } = useForm({
         resolver: yupResolver(transferNFTSchema),
         mode: 'all',
     });

--- a/src/utils/validation/SendFundsModal.js
+++ b/src/utils/validation/SendFundsModal.js
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 const requiredMessageType = {
     recipientId: 'Please enter recipient\'s address',
-    amount: 'Please enter a valid multisig name',
+    amount: 'Please enter a valid amount to send',
 };
 
 export const sendFundsSchema = yup.object().shape({


### PR DESCRIPTION
Fix: Send FT/NFT and make function call flows were not showing proper error strings during form validation

<img width="525" alt="Screen Shot 2022-07-21 at 2 05 27 PM" src="https://user-images.githubusercontent.com/24921205/180285103-c6a9d472-b135-48e1-87e6-afcb1663f1a5.png">
