### PR TITLE
bug-fix: View In Explorer Link does not work for pending actions

### DIFF
--- a/src/ui/components/Main/MultiSafe/Dashboard/Transactions/Recipient/Recipient.jsx
+++ b/src/ui/components/Main/MultiSafe/Dashboard/Transactions/Recipient/Recipient.jsx
@@ -4,7 +4,7 @@ import { CopyToClipboard } from '../../../general/CopyToClipboard/CopyToClipboar
 import { OpenInExplorer } from '../../../general/OpenInExplorer/OpenInExplorer';
 import { useStyles } from './Recipient.styles';
 
-export const Recipient = ({ recipient, transactionHash }) => {
+export const Recipient = ({ recipient }) => {
     const classes = useStyles();
     return (
         <TableCell>
@@ -15,8 +15,6 @@ export const Recipient = ({ recipient, transactionHash }) => {
             />
             <OpenInExplorer
                 accountId={recipient}
-                type="transaction"
-                transactionHash={transactionHash}
                 classNames={{ iconButton: classes.openInExplorer, icon: classes.icon }}
             />
         </TableCell>

--- a/src/ui/components/Main/MultiSafe/History/Transactions/Recipient/Recipient.jsx
+++ b/src/ui/components/Main/MultiSafe/History/Transactions/Recipient/Recipient.jsx
@@ -4,7 +4,7 @@ import { CopyToClipboard } from '../../../general/CopyToClipboard/CopyToClipboar
 import { OpenInExplorer } from '../../../general/OpenInExplorer/OpenInExplorer';
 import { useStyles } from './Recipient.styles';
 
-export const Recipient = ({ recipient, transactionHash }) => {
+export const Recipient = ({ recipient }) => {
     const classes = useStyles();
     return (
         <TableCell>
@@ -15,8 +15,6 @@ export const Recipient = ({ recipient, transactionHash }) => {
             />
             <OpenInExplorer
                 accountId={recipient}
-                type="transaction"
-                transactionHash={transactionHash}
                 classNames={{ iconButton: classes.openInExplorer, icon: classes.icon }}
             />
         </TableCell>

--- a/src/ui/components/Main/MultiSafe/History/Transactions/Requests.jsx
+++ b/src/ui/components/Main/MultiSafe/History/Transactions/Requests.jsx
@@ -43,9 +43,9 @@ export const Requests = () => {
                                     <TableCell>{request.requestId}</TableCell>
                                     <TableCell>{dateFormat(request.createdAt, 'd mmm yyyy - HH:MM')}</TableCell>
                                     <Type type={request.type} />
-                                    <Recipient recipient={request.recipient} transactionHash={request.transactionHash} />
+                                    <Recipient recipient={request.recipient} />
                                     <TableCell>{formatNearBalance(request.amount)}</TableCell>
-                                    <Status status={request.status} />
+                                    <Status status={request.status} transactionHash={request.transactionHash}/>
                                 </TableRow>
                             ))}
                         </TableBody>

--- a/src/ui/components/Main/MultiSafe/History/Transactions/Status/Status.jsx
+++ b/src/ui/components/Main/MultiSafe/History/Transactions/Status/Status.jsx
@@ -1,8 +1,16 @@
 import { TableCell } from '@material-ui/core';
 
+import { OpenInExplorer } from '../../../general/OpenInExplorer/OpenInExplorer';
 import { useStyles } from './Status.styles';
 
-export const Status = ({ status }) => {
+export const Status = ({ status, transactionHash}) => {
     const classes = useStyles({ status });
-    return <TableCell className={classes.status}>{status}</TableCell>;
+    return <TableCell className={classes.status}>
+        {status}
+        <OpenInExplorer
+            classNames={{ iconButton: classes.openInExplorer, icon: classes.icon }}
+            type="transaction"
+            transactionHash={transactionHash}
+        />
+    </TableCell>;
 };

--- a/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
+++ b/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
@@ -4,13 +4,16 @@ import { OpenInNew } from '@material-ui/icons';
 import { config } from '../../../../../../near/config';
 
 const getHref = ({ accountId, type, transactionHash }) => {
-    if (type === 'account' && accountId) {
-        return config.getCheckAccountInExplorerUrl(accountId);
+    switch (type) {
+        case 'account':
+            return config.getCheckAccountInExplorerUrl(accountId);
+        case 'transaction':
+            if (!transactionHash) 
+                return config.getCheckAccountInExplorerUrl(accountId);
+            return config.getCheckTransactionInExplorerUrl(transactionHash);
+        default:
+            return null;
     }
-    if (type === 'transaction' && transactionHash) {
-        return config.getCheckTransactionInExplorerUrl(transactionHash);
-    }
-    return null;
 };
 
 export const OpenInExplorer = ({ accountId, transactionHash, classNames, type = 'account' }) => {

--- a/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
+++ b/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
@@ -4,13 +4,16 @@ import { OpenInNew } from '@material-ui/icons';
 import { config } from '../../../../../../near/config';
 
 const getHref = ({ accountId, type, transactionHash }) => {
+    const getAccountInExplorerUrl =  (accountId) => `${config.explorerUrl}/accounts/${accountId}`;
+    const getTransactionInExplorerUrl = (transactionHash) => `${config.explorerUrl}/transactions/${transactionHash}`;
+
     switch (type) {
         case 'account':
-            return config.getCheckAccountInExplorerUrl(accountId);
+            return getAccountInExplorerUrl(accountId);
         case 'transaction':
             if (!transactionHash) 
-                return config.getCheckAccountInExplorerUrl(accountId);
-            return config.getCheckTransactionInExplorerUrl(transactionHash);
+                return getAccountInExplorerUrl(accountId);
+            return getTransactionInExplorerUrl(transactionHash);
         default:
             return null;
     }

--- a/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
+++ b/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
@@ -3,26 +3,22 @@ import { OpenInNew } from '@material-ui/icons';
 
 import { config } from '../../../../../../near/config';
 
-const getExplorerLink = ({ accountId, type, transactionHash }) => {
-    const getAccountInExplorerUrl =  (accountId) => `${config.explorerUrl}/accounts/${accountId}`;
-    const getTransactionInExplorerUrl = (transactionHash) => `${config.explorerUrl}/transactions/${transactionHash}`;
-
-    switch (type) {
-        case 'account':
-            return getAccountInExplorerUrl(accountId);
-        case 'transaction':
-            return getTransactionInExplorerUrl(transactionHash);
-        default:
-            return null;
+const getHref = ({ accountId, type, transactionHash }) => {
+    if (type === 'account' && accountId) {
+        return config.getCheckAccountInExplorerUrl(accountId);
     }
+    if (type === 'transaction' && transactionHash) {
+        return config.getCheckTransactionInExplorerUrl(transactionHash);
+    }
+    return null;
 };
 
 export const OpenInExplorer = ({ accountId, transactionHash, classNames, type = 'account' }) => {
-    const linkToExplorer = getExplorerLink({ accountId, transactionHash, type });
+    const href = getHref({ accountId, transactionHash, type });
 
     return (
         <IconButton className={classNames?.iconButton}>
-            <a href={linkToExplorer} target="_blank" rel="noreferrer">
+            <a href={href} target="_blank" rel="noreferrer">
                 <Tooltip title={`View ${type} in explorer`} placement="top">
                     <OpenInNew className={classNames?.icon} />
                 </Tooltip>

--- a/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
+++ b/src/ui/components/Main/MultiSafe/general/OpenInExplorer/OpenInExplorer.jsx
@@ -3,7 +3,7 @@ import { OpenInNew } from '@material-ui/icons';
 
 import { config } from '../../../../../../near/config';
 
-const getHref = ({ accountId, type, transactionHash }) => {
+const getExplorerLink = ({ accountId, type, transactionHash }) => {
     const getAccountInExplorerUrl =  (accountId) => `${config.explorerUrl}/accounts/${accountId}`;
     const getTransactionInExplorerUrl = (transactionHash) => `${config.explorerUrl}/transactions/${transactionHash}`;
 
@@ -11,8 +11,6 @@ const getHref = ({ accountId, type, transactionHash }) => {
         case 'account':
             return getAccountInExplorerUrl(accountId);
         case 'transaction':
-            if (!transactionHash) 
-                return getAccountInExplorerUrl(accountId);
             return getTransactionInExplorerUrl(transactionHash);
         default:
             return null;
@@ -20,11 +18,11 @@ const getHref = ({ accountId, type, transactionHash }) => {
 };
 
 export const OpenInExplorer = ({ accountId, transactionHash, classNames, type = 'account' }) => {
-    const href = getHref({ accountId, transactionHash, type });
+    const linkToExplorer = getExplorerLink({ accountId, transactionHash, type });
 
     return (
         <IconButton className={classNames?.iconButton}>
-            <a href={href} target="_blank" rel="noreferrer">
+            <a href={linkToExplorer} target="_blank" rel="noreferrer">
                 <Tooltip title={`View ${type} in explorer`} placement="top">
                     <OpenInNew className={classNames?.icon} />
                 </Tooltip>


### PR DESCRIPTION
In the Recipient column of Requests Completed, the 'view in explorer link' takes the user to the transaction page on-chain. Additionally, on the Requests Pending page, the Recipient column does not work. 

**Changes**
 - In the recipient column requests Completed/Pending should take the user to the account page. 
 - Added a link to the requests Completed page under the `Completed` column to take the user to the on-chain tx. 

### **BEFORE**
![err_ui_safe](https://user-images.githubusercontent.com/25015977/180854682-cb20fdee-30dc-4966-a628-b8e75ced9d8b.gif)

### **AFTER**
![fixed_tx_link](https://user-images.githubusercontent.com/25015977/181285991-92ec7d94-6057-42ab-8e91-b41a1f6be974.gif)

