### PR TITLE
Bug-fix: Streamlined Submit form button behavior on all forms

### DIFF
--- a/src/ui/components/Main/FormElements/FormButton/FormButton.jsx
+++ b/src/ui/components/Main/FormElements/FormButton/FormButton.jsx
@@ -1,0 +1,34 @@
+import { Button } from '@material-ui/core';
+import { withRouter } from 'react-router';
+
+const FormButton = ({ 
+    children, 
+    type='submit', 
+    disabled = false,
+    onClick,
+    linkTo,
+    history,
+    className,
+    variant,
+    color = 'primary',
+    sending = false,
+    sendingString,
+}) => (
+    <Button
+        type={type}
+        variant={variant}
+        color={color}
+        className={className}
+        disabled={disabled}
+        onClick={(e) => {
+            onClick && onClick(e);
+            linkTo && (linkTo.toLowerCase().startsWith('http') ? window.open(linkTo, '_blank') : history.push(linkTo));
+        }}
+    >
+        { 
+            sending ? (sendingString ? sendingString : 'sending') : children
+        }
+    </Button>
+);
+
+export default withRouter(FormButton);

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/Form.jsx
@@ -1,5 +1,4 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button } from '@material-ui/core';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -7,6 +6,7 @@ import { useHistory } from 'react-router-dom';
 
 import { EditSafeSchema } from '../../../../../../utils/validation/EditMembersPage';
 import { Confirmations } from '../../../FormElements/Confirmations/Confirmations';
+import FormButton from '../../../FormElements/FormButton/FormButton';
 import { MembersField } from '../../../FormElements/MembersField/MembersField';
 import { MultisafeName } from '../../../FormElements/MultisafeName/MultisafeName';
 import { ConfirmModal } from '../ConfirmModal/ConfirmModal';
@@ -24,12 +24,13 @@ export const Form = () => {
 
     const [isOpenConfirmModal, setOpenConfirmModal] = useState(false);
     const [formData, setFormData] = useState();
-
+  
     const {
         control,
         handleSubmit,
         getValues,
-        formState: { errors }
+        reset,
+        formState: { errors, isValid, isDirty }
     } = useForm({
         resolver: yupResolver(EditSafeSchema),
         mode: 'all',
@@ -41,15 +42,15 @@ export const Form = () => {
             num_confirmations: numConfirmations
         }
     });
-
+    
     const onSubmit = handleSubmit(async (data) => {
         if (await isBatchRequest({ data, history })) {
             setOpenConfirmModal(true);
             setFormData(data);
             return;
         }
-
-        onEditMultisafe({ data, history });
+        await onEditMultisafe({ data, history });
+        reset(data);
     });
 
     return (
@@ -82,9 +83,9 @@ export const Form = () => {
                     hasError={!!errors?.num_confirmations}
                     errorMessage={!!errors?.num_confirmations && errors?.num_confirmations?.message}
                 />
-                <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
+                <FormButton disabled={!isValid || !isDirty } variant="contained" className={classes.submitButton}>
                     Send Request
-                </Button>
+                </FormButton>
             </form>
         </>
     );

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormDisconnect.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormDisconnect.jsx
@@ -1,8 +1,9 @@
-import { Button, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import { useStoreActions } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 
+import FormButton from '../../../FormElements/FormButton/FormButton';
 import { useStyles } from './Form.styles';
 
 export const FormDisconnect = () => {
@@ -12,6 +13,7 @@ export const FormDisconnect = () => {
 
     const {
         handleSubmit,
+        formState: {isValid}
     } = useForm({
         mode: 'all',
     });
@@ -23,9 +25,9 @@ export const FormDisconnect = () => {
             <Typography className={classes?.description}>
         Disconnecting the account will not remove the Safe, you will be able to connect your wallet again.
             </Typography>
-            <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-        Disconnect Account
-            </Button>
+            <FormButton disabled={!isValid} variant="contained" className={classes.submitButton}>
+                Disconnect Account
+            </FormButton>
         </form>
     );
 };

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormDisconnect.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormDisconnect.jsx
@@ -13,7 +13,6 @@ export const FormDisconnect = () => {
 
     const {
         handleSubmit,
-        formState: {isValid}
     } = useForm({
         mode: 'all',
     });
@@ -25,7 +24,7 @@ export const FormDisconnect = () => {
             <Typography className={classes?.description}>
         Disconnecting the account will not remove the Safe, you will be able to connect your wallet again.
             </Typography>
-            <FormButton disabled={!isValid} variant="contained" className={classes.submitButton}>
+            <FormButton variant="contained" className={classes.submitButton}>
                 Disconnect Account
             </FormButton>
         </form>

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormRemove.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormRemove.jsx
@@ -14,7 +14,6 @@ export const FormRemove = () => {
 
     const {
         handleSubmit,
-        formState: {isValid}
     } = useForm({
         mode: 'all',
     });
@@ -29,7 +28,7 @@ export const FormRemove = () => {
             <Typography className={classes?.description}>
                 Notice that it will be removed only locally from your browser - you won&apos;t delete it from the blockchain.
             </Typography>
-            <FormButton disabled={!isValid} variant="contained" className={classes.submitButton}>
+            <FormButton variant="contained" className={classes.submitButton}>
             Remove Multi Safe
             </FormButton>
         </form>

--- a/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormRemove.jsx
+++ b/src/ui/components/Main/MultiSafe/EditMultisafe/Form/FormRemove.jsx
@@ -1,8 +1,9 @@
-import { Button, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 
+import FormButton from '../../../FormElements/FormButton/FormButton';
 import { useStyles } from './Form.styles';
 
 export const FormRemove = () => {
@@ -13,6 +14,7 @@ export const FormRemove = () => {
 
     const {
         handleSubmit,
+        formState: {isValid}
     } = useForm({
         mode: 'all',
     });
@@ -27,9 +29,9 @@ export const FormRemove = () => {
             <Typography className={classes?.description}>
                 Notice that it will be removed only locally from your browser - you won&apos;t delete it from the blockchain.
             </Typography>
-            <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-                Remove Multi Safe
-            </Button>
+            <FormButton disabled={!isValid} variant="contained" className={classes.submitButton}>
+            Remove Multi Safe
+            </FormButton>
         </form>
     );
 };

--- a/src/ui/components/Main/MultiSafe/MultisafeList/List/Item/More/EditModal/EditModal.jsx
+++ b/src/ui/components/Main/MultiSafe/MultisafeList/List/Item/More/EditModal/EditModal.jsx
@@ -4,6 +4,7 @@ import cn from 'classnames';
 import { useStoreActions } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
 
+import FormButton from '../../../../../../FormElements/FormButton/FormButton';
 import { useStyles } from './EditModal.styles';
 import { MultisafeName } from './MultisafeName/MultisafeName';
 import { validationSchema } from './validationSchema';
@@ -21,7 +22,8 @@ export const EditModal = ({
     const {
         control,
         handleSubmit,
-        formState: { errors },
+        reset,
+        formState: { errors, isValid, isDirty },
     } = useForm({
         resolver: yupResolver(validationSchema),
         mode: 'all',
@@ -30,6 +32,7 @@ export const EditModal = ({
     const onSubmit = handleSubmit((data) => {
         changeMultisafeName({ multisafeId, data });
         closeEditModal();
+        reset(data);
     });
 
     return (
@@ -53,9 +56,9 @@ export const EditModal = ({
                             <Button className={classes.cancel} onClick={closeEditModal}>
                 Cancel
                             </Button>
-                            <Button type="submit" color="primary" className={cn(classes.cancel, classes.send)}>
-                Save
-                            </Button>
+                            <FormButton disabled={!isValid || !isDirty} className={cn(classes.cancel, classes.send)}>
+                                Save
+                            </FormButton>
                         </div>
                     </form>
                 </div>

--- a/src/ui/components/Main/MultiSafe/NonFungibleTokens/Actions/TransferNFT.jsx
+++ b/src/ui/components/Main/MultiSafe/NonFungibleTokens/Actions/TransferNFT.jsx
@@ -7,13 +7,15 @@ import { useForm } from 'react-hook-form';
 
 import { transferNFTSchema } from '../../../../../../utils/validation/SendFundsModal';
 import { Checkbox } from '../../../../general/Checkbox/Checkbox';
+import FormButton from '../../../FormElements/FormButton/FormButton';
 import { Recipient } from '../../Sidebar/Actions/NewTransaction/SendFunds/Recipient/Recipient';
 import { useStyles } from '../../Sidebar/Actions/NewTransaction/SendFunds/SendFunds.styles';
 
+       
 export const TransferNFT = forwardRef(({ onClose, tabIndex, tokenId, contractName, tokenName }, ref) => {
     const onTransferNFT = useStoreActions((actions) => actions.multisafe.onTransferNFT);
 
-    const { control, handleSubmit, errors } = useForm({
+    const { control, handleSubmit, errors, reset, formState: {isValid, isDirty} } = useForm({
         resolver: yupResolver(transferNFTSchema),
         mode: 'all',
     });
@@ -21,6 +23,7 @@ export const TransferNFT = forwardRef(({ onClose, tabIndex, tokenId, contractNam
 
     const onSubmit = handleSubmit((data) => {
         onTransferNFT({ data, onClose, tokenId, contractName });
+        reset(data);
     });
 
     return (
@@ -54,9 +57,9 @@ export const TransferNFT = forwardRef(({ onClose, tabIndex, tokenId, contractNam
                         <Button color="secondary" className={classes.cancel} onClick={onClose}>
               Cancel
                         </Button>
-                        <Button type="submit" color="primary" className={cn(classes.cancel, classes.send)}>
-              Send
-                        </Button>
+                        <FormButton disabled={!isValid || !isDirty} className={cn(classes.cancel, classes.send)}>
+                        Send
+                        </FormButton>
                     </div>
                 </form>
             </div>

--- a/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/MakeFunctionCall/MakeFunctionCall.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/MakeFunctionCall/MakeFunctionCall.jsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 
 import { makeFunctionCallSchema } from '../../../../../../../../utils/validation/makeFunctionCallModal';
 import { Checkbox } from '../../../../../../general/Checkbox/Checkbox';
+import FormButton from '../../../../../FormElements/FormButton/FormButton';
 import { Arguments } from './arguments/Arguments';
 import { Deposit } from './Deposit/Deposit';
 import { useStyles } from './MakeFunctionCall.styles';
@@ -14,9 +15,10 @@ import { MethodName } from './MethodName/MethodName';
 import { SmartContractAddress } from './SmartContractAddress/SmartContractAddress';
 import { TGas } from './TGas/TGas';
 
+
 export const MakeFunctionCall = forwardRef(({ onClose, tabIndex }, ref) => {
     const onMakeFunctionCall = useStoreActions((actions) => actions.multisafe.onMakeFunctionCall);
-    const { control, handleSubmit, formState: { errors } } = useForm({
+    const { control, handleSubmit, reset, formState: { errors, isValid, isDirty } } = useForm({
         resolver: yupResolver(makeFunctionCallSchema),
         mode: 'all',
     });
@@ -24,6 +26,7 @@ export const MakeFunctionCall = forwardRef(({ onClose, tabIndex }, ref) => {
 
     const onSubmit = handleSubmit((data) => {
         onMakeFunctionCall({ data, onClose });
+        reset(data);
     });
 
     return (
@@ -73,9 +76,9 @@ export const MakeFunctionCall = forwardRef(({ onClose, tabIndex }, ref) => {
                         <Button color='secondary' className={classes.cancel} onClick={onClose}>
                             Cancel
                         </Button>
-                        <Button type='submit' color='primary' className={cn(classes.cancel, classes.send)}>
-                            Make function call
-                        </Button>
+                        <FormButton disabled={!isValid || !isDirty} className={cn(classes.cancel, classes.send)}>
+                        Make function call
+                        </FormButton>
                     </div>
                 </form>
             </div>

--- a/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendFunds.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendFunds.jsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 
 import { sendFundsSchema } from '../../../../../../../../utils/validation/SendFundsModal';
 import { Checkbox } from '../../../../../../general/Checkbox/Checkbox';
+import FormButton from '../../../../../FormElements/FormButton/FormButton';
 import { Amount } from './Amount/Amount';
 import { Recipient } from './Recipient/Recipient';
 import { useStyles } from './SendFunds.styles';
@@ -16,7 +17,7 @@ export const SendFunds = forwardRef(({ onClose, tabIndex }, ref) => {
     const onTransferTokens = useStoreActions((actions) => actions.multisafe.onTransferTokens);
     const fungibleTokens = useStoreState((store) => store.multisafe.general.fungibleTokens);
 
-    const { control, handleSubmit, setValue, formState: { errors } } = useForm({
+    const { control, handleSubmit, setValue, reset, formState: { errors, isValid, isDirty } } = useForm({
         resolver: yupResolver(sendFundsSchema),
         mode: 'all',
     });
@@ -27,6 +28,7 @@ export const SendFunds = forwardRef(({ onClose, tabIndex }, ref) => {
             ? fungibleTokens.find(({name}) => name === tokenName) 
             : undefined;
         onTransferTokens({ data, onClose, token});
+        reset(data);
     });
 
     return (
@@ -59,9 +61,9 @@ export const SendFunds = forwardRef(({ onClose, tabIndex }, ref) => {
                     <Button color="secondary" className={classes.cancel} onClick={onClose}>
                         Cancel
                     </Button>
-                    <Button type="submit" color="primary" className={cn(classes.cancel, classes.send)}>
+                    <FormButton disabled={!isValid || !isDirty} className={cn(classes.cancel, classes.send)}>
                         Send
-                    </Button>
+                    </FormButton>
                 </div>
             </form>
         </div>

--- a/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendNFTs.jsx
+++ b/src/ui/components/Main/MultiSafe/Sidebar/Actions/NewTransaction/SendFunds/SendNFTs.jsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 
 import { transferNFTSchema } from '../../../../../../../../utils/validation/SendFundsModal';
 import { Checkbox } from '../../../../../../general/Checkbox/Checkbox';
+import FormButton from '../../../../../FormElements/FormButton/FormButton';
 import { NFT } from './Collection/NFT';
 import { NFTCollection } from './Collection/NFTCollection';
 import { Recipient } from './Recipient/Recipient';
@@ -17,7 +18,7 @@ const VIEWS = {
     CHOOSE_RECIPIENT: 'chooseRecipient'
 };
 
-const TransferView = ({ nonFungibleTokens, currentView, setCurrentView, onClose, control, errors, classes, onClick, tokenId, contractName }) => {
+const TransferView = ({ nonFungibleTokens, currentView, setCurrentView, onClose, control, errors, isValid, isDirty, classes, onClick, tokenId, contractName }) => {
     switch (currentView) {
         case VIEWS.CHOOSE_NFT: {
             const onClickNext = () => setCurrentView(VIEWS.CHOOSE_RECIPIENT);
@@ -85,13 +86,9 @@ const TransferView = ({ nonFungibleTokens, currentView, setCurrentView, onClose,
                         >
                             Previous
                         </Button>
-                        <Button
-                            type="submit"
-                            color="primary"
-                            className={cn(classes.cancel, classes.send)}
-                        >
+                        <FormButton disabled={!isValid || !isDirty} className={cn(classes.cancel, classes.send)}>
                             Send
-                        </Button>
+                        </FormButton>
                     </div>
                 </>
             );
@@ -109,7 +106,7 @@ export const SendNFTs = forwardRef(({ onClose, tabIndex }, ref) => {
     const nonFungibleTokens = useStoreState(({ multisafe }) => multisafe.general.nonFungibleTokens);
     const onTransferNFT = useStoreActions((actions) => actions.multisafe.onTransferNFT);
 
-    const { control, handleSubmit, formState: { errors } } = useForm({
+    const { control, handleSubmit, reset, formState: { errors, isValid, isDirty } } = useForm({
         resolver: yupResolver(transferNFTSchema),
         mode: 'all',
     });
@@ -117,6 +114,7 @@ export const SendNFTs = forwardRef(({ onClose, tabIndex }, ref) => {
 
     const onSubmit = handleSubmit((data) => {
         onTransferNFT({ data, onClose, tokenId, contractName });
+        reset(data);
     });
 
     const onClick = ({id, contract}) => {
@@ -128,7 +126,7 @@ export const SendNFTs = forwardRef(({ onClose, tabIndex }, ref) => {
     return (
         <div className={classes.wrapper}>
             <form className={classes.form} onSubmit={onSubmit}>
-                {TransferView({ nonFungibleTokens, currentView, setCurrentView, onClose, control, errors, classes, onClick, tokenId, contractName })}
+                {TransferView({ nonFungibleTokens, currentView, setCurrentView, onClose, control, errors, isValid, isDirty, classes, onClick, tokenId, contractName })}
             </form>
         </div>
     );

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { createMultisafeSchema } from '../../../../../../utils/validation/Create
 import { AccountId } from '../../../FormElements/AccountId/AccountId';
 import { Amount } from '../../../FormElements/Amount/Amount';
 import { Confirmations } from '../../../FormElements/Confirmations/Confirmations';
+import FormButton from '../../../FormElements/FormButton/FormButton';
 import { MembersField } from '../../../FormElements/MembersField/MembersField';
 import { MultisafeName } from '../../../FormElements/MultisafeName/MultisafeName';
 import { useStyles } from './Form.styles';
@@ -22,7 +23,8 @@ export const Form = () => {
         control,
         handleSubmit,
         getValues,
-        formState: { errors },
+        reset,
+        formState: { errors, isDirty },
     } = useForm({
         resolver: yupResolver(createMultisafeSchema),
         mode: 'all',
@@ -32,7 +34,10 @@ export const Form = () => {
         },
     });
 
-    const onSubmit = handleSubmit((data) => onCreateMultisafe({ data, history }));
+    const onSubmit = handleSubmit((data) => {
+        onCreateMultisafe({ data, history });
+        reset(data);
+    });
 
     return (
         <form autoComplete="off" className={classes.form} onSubmit={onSubmit}>
@@ -70,9 +75,9 @@ export const Form = () => {
             <Typography className={classes.policy}>
                 By continuing you consent to the terms of use and privacy policy.
             </Typography>
-            <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-                Create Multi Safe
-            </Button>
+            <FormButton disabled={!isDirty} variant="contained" className={classes.submitButton}>
+            Create Multi Safe
+            </FormButton>
         </form>
     );
 };

--- a/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/CreateMultisafe/Form/Form.jsx
@@ -24,13 +24,14 @@ export const Form = () => {
         handleSubmit,
         getValues,
         reset,
-        formState: { errors, isDirty },
+        formState: { errors, isValid, isDirty },
     } = useForm({
         resolver: yupResolver(createMultisafeSchema),
         mode: 'all',
         defaultValues: {
             members: [{ account_id: accountId }],
             num_confirmations: '1',
+            amount: '5' 
         },
     });
 
@@ -75,7 +76,7 @@ export const Form = () => {
             <Typography className={classes.policy}>
                 By continuing you consent to the terms of use and privacy policy.
             </Typography>
-            <FormButton disabled={!isDirty} variant="contained" className={classes.submitButton}>
+            <FormButton disabled={!isValid || !isDirty} variant="contained" className={classes.submitButton}>
             Create Multi Safe
             </FormButton>
         </form>

--- a/src/ui/components/Main/StartWork/LoadMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/LoadMultisafe/Form/Form.jsx
@@ -13,7 +13,7 @@ export const Form = () => {
     const near = useStoreState((state) => state.general.entities.near);
     const multisafes = useStoreState((state) => state.multisafe.multisafes);
     const onLoadMultisafe = useStoreActions((actions) => actions.startWork.onLoadMultisafe);
-    const { control, handleSubmit, reset, formState: { errors, isValid, isDirty}} = useForm({
+    const { control, handleSubmit, reset, formState: { errors }} = useForm({
         resolver,
         context: { near, multisafes: new Set(multisafes.map((multisafe) => multisafe.multisafeId)) },
     });
@@ -49,7 +49,7 @@ export const Form = () => {
         By continuing you consent to the terms of use and privacy policy.
             </Typography>
             <Divider className={classes.divider} />
-            <FormButton disabled={!isValid || !isDirty } variant="contained" className={classes.submitButton}>
+            <FormButton variant="contained" className={classes.submitButton}>
             Load Multi Safe
             </FormButton>
         </form>

--- a/src/ui/components/Main/StartWork/LoadMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/LoadMultisafe/Form/Form.jsx
@@ -1,17 +1,19 @@
-import { Button, Divider, Typography } from '@material-ui/core';
+import { Divider, Typography } from '@material-ui/core';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 
+import FormButton from '../../../FormElements/FormButton/FormButton';
 import { TextField } from '../../../general/TextField/TextField';
 import { useStyles } from './Form.styles';
 import { resolver } from './validations';
+
 
 export const Form = () => {
     const near = useStoreState((state) => state.general.entities.near);
     const multisafes = useStoreState((state) => state.multisafe.multisafes);
     const onLoadMultisafe = useStoreActions((actions) => actions.startWork.onLoadMultisafe);
-    const { control, handleSubmit, formState } = useForm({
+    const { control, handleSubmit, reset, formState: { errors, isValid, isDirty}} = useForm({
         resolver,
         context: { near, multisafes: new Set(multisafes.map((multisafe) => multisafe.multisafeId)) },
     });
@@ -20,8 +22,9 @@ export const Form = () => {
 
     const onSubmit = handleSubmit((data) => {
         onLoadMultisafe({ data, push });
+        reset(data);
     });
-
+    
     return (
         <form className={classes.form} onSubmit={onSubmit}>
             <TextField
@@ -30,8 +33,8 @@ export const Form = () => {
                 variant="outlined"
                 placeholder="MultiSafe Name"
                 className={classes.textField}
-                error={formState.errors?.name}
-                helperText={formState.errors?.name?.message}
+                error={errors?.name}
+                helperText={errors?.name?.message}
             />
             <TextField
                 control={control}
@@ -39,16 +42,16 @@ export const Form = () => {
                 variant="outlined"
                 placeholder="MultiSafe Account ID"
                 className={classes.textField}
-                error={formState.errors?.multisafeId}
-                helperText={formState.errors?.multisafeId?.message}
+                error={errors?.multisafeId}
+                helperText={errors?.multisafeId?.message}
             />
             <Typography className={classes.terms}>
         By continuing you consent to the terms of use and privacy policy.
             </Typography>
             <Divider className={classes.divider} />
-            <Button type="submit" variant="contained" color="primary" className={classes.submitButton}>
-        Load Multi Safe
-            </Button>
+            <FormButton disabled={!isValid || !isDirty } variant="contained" className={classes.submitButton}>
+            Load Multi Safe
+            </FormButton>
         </form>
     );
 };

--- a/src/ui/components/Main/StartWork/LoadMultisafe/Form/Form.jsx
+++ b/src/ui/components/Main/StartWork/LoadMultisafe/Form/Form.jsx
@@ -13,8 +13,9 @@ export const Form = () => {
     const near = useStoreState((state) => state.general.entities.near);
     const multisafes = useStoreState((state) => state.multisafe.multisafes);
     const onLoadMultisafe = useStoreActions((actions) => actions.startWork.onLoadMultisafe);
-    const { control, handleSubmit, reset, formState: { errors }} = useForm({
+    const { control, handleSubmit, reset, formState: { errors, isValid, isDirty }} = useForm({
         resolver,
+        mode: 'all',
         context: { near, multisafes: new Set(multisafes.map((multisafe) => multisafe.multisafeId)) },
     });
     const { push } = useHistory();
@@ -49,7 +50,7 @@ export const Form = () => {
         By continuing you consent to the terms of use and privacy policy.
             </Typography>
             <Divider className={classes.divider} />
-            <FormButton variant="contained" className={classes.submitButton}>
+            <FormButton disabled={!isValid || !isDirty} variant="contained" className={classes.submitButton}>
             Load Multi Safe
             </FormButton>
         </form>


### PR DESCRIPTION
This PR addresses Issue #112 to prevent the user from pressing a form button twice. It also addresses a UX bug that keeps the form button disabled until the form is valid as well as changes have been made to it. No reason to keep the form button always in the clickable state when there are not any changes to be submitted. 

This behavior was changed on all flows using a form button for submission. 

**Solution**
- Take a similar approach to Near-Wallet by creating a reusable FormButton component
- Take advantage of Yup Resolver's isDirty & isValid state to enable/disable form buttons
- Create mutlisafe form Amount has a default value of 5. 


**Note**: The FormButton component comes with a few handy features that we can take advantage of in future PRs such as redirecting the user to a specific screen in the app upon the button being pressed, changing the text of the button while a form is being submitted.
