### PR TITLE
fix: fixed valid custom css rule against wallet-selector img

### DIFF
--- a/src/ui/providers/WalletSelectorProvider/custom.css
+++ b/src/ui/providers/WalletSelectorProvider/custom.css
@@ -1,8 +1,3 @@
 .nws-modal-wrapper .spinner img {
-  width: calc(var(--size) / 1.2);
-  height: calc(var(--size) / 1.2);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  border-radius: 50%;
-  box-shadow: rgb(0 0 0 / 5%) 0 10px 20px 0;
-  padding: 0;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
This PR contains fixes for custom css rule applied against `wallet-selector` UI component. 

Previous 
<img width="527" alt="image" src="https://user-images.githubusercontent.com/6027014/183323890-d2713227-ca75-4247-8933-c1ccf87cab8d.png">


Current:
<img width="531" alt="image" src="https://user-images.githubusercontent.com/6027014/183323852-51c427d4-7a89-4ee2-8f9a-ae71f2b16e18.png">
